### PR TITLE
Harden code scanning alert handling

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -59,6 +59,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      codeql-actions:
+        patterns:
+          - "github/codeql-action/*"
     open-pull-requests-limit: 10
     assignees:
       - "VanL"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,7 +28,7 @@ jobs:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         with:
           languages: python
 

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -7,20 +7,39 @@ permissions:
 jobs:
   dependabot:
     runs-on: ubuntu-latest
+    timeout-minutes: 130
     if: ${{ github.actor == 'dependabot[bot]' }}
     permissions:
+      actions: read
       contents: write
       pull-requests: write
     steps:
+      - name: Checkout gate script
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
       - name: Dependabot metadata
         id: metadata
         uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-      
-      - name: Enable auto-merge for Dependabot PRs
+
+      - name: Require sibling workflows to pass
         if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch' }}
-        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python .github/scripts/require_green_workflows.py \
+            --sha "${{ github.event.pull_request.head.sha }}" \
+            --workflow "Test" \
+            --workflow "Test Postgres Extension" \
+            --workflow "Test Redis Extension" \
+            --workflow "CodeQL"
+
+      - name: Merge green Dependabot PR
+        if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch' }}
+        run: gh pr merge --merge "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -30,11 +30,16 @@ jobs:
           # Pinned below latest: Atheris wheels lag the newest CPython.
           python-version: "3.12"
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.3.2
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            pyproject.toml
+            uv.lock
+
       - name: Install
-        run: |
-          python -m pip install --upgrade pip
-          pip install atheris hypothesis pytest
-          pip install .
+        run: uv sync --frozen --extra dev --group fuzz
 
       - name: Restore corpus
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -49,7 +54,7 @@ jobs:
       - name: Fuzz (15 minutes)
         run: |
           mkdir -p fuzz/corpus/${{ matrix.harness }}
-          python fuzz/fuzz_${{ matrix.harness }}.py \
+          uv run --frozen --no-sync python fuzz/fuzz_${{ matrix.harness }}.py \
             fuzz/corpus/${{ matrix.harness }} \
             -max_total_time=900 -print_final_stats=1
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -5,6 +5,7 @@ on:
     branches: [main, master]
   schedule:
     - cron: "30 1 * * 6"
+  workflow_dispatch:
 
 permissions: read-all
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -128,10 +128,6 @@ jobs:
           extensions/simplebroker_redis/pyproject.toml
           extensions/simplebroker_redis/uv.lock
 
-    - name: Install build tools
-      run: |
-        python -m pip install build
-
     - name: Run packaging smoke
       run: |
         uv run ./bin/packaging-smoke --python 3.11

--- a/docs/plans/2026-07-12-code-scanning-alert-triage-plan.md
+++ b/docs/plans/2026-07-12-code-scanning-alert-triage-plan.md
@@ -89,8 +89,10 @@ solo-maintainer workflow.
 
 Do not teach generic `_run()` logging to guess which arbitrary arguments are
 secret. For the Docker password, pass `--env POSTGRES_PASSWORD` and place the
-value only in the subprocess environment. For DSNs intentionally displayed to a
-developer, call the existing `redact_backend_target()` chokepoint.
+value only in the subprocess environment. Keep using `redact_backend_target()`
+where connection details are intentionally useful. The benchmark does not need
+connection details, so print a constant `[redacted]` marker there instead of
+passing sensitive data through another analyzer-visible sink.
 
 ### Use the repository lock, not hand-maintained requirements hashes
 
@@ -206,7 +208,7 @@ upload results successfully. A configuration-error SARIF upload is not a pass.
      unchanged.
 2. In `tests/test_backend_benchmark_smoke.py`, provision a fake Docker DSN with a
    distinctive password, enter `_postgres_dsn_for_benchmark()`, and assert the
-   captured output contains `***` and never the secret.
+   captured output is the constant `[redacted]` message and never the secret.
 3. Keep `test_pytest_pg_main_redacts_dsn_password` green. It is the regression
    evidence for the sink reported by false-positive alert `#29`.
 
@@ -216,8 +218,9 @@ upload results successfully. A configuration-error SARIF upload is not a pass.
    `POSTGRES_PASSWORD`, `POSTGRES_USER`, and `POSTGRES_DB` in that copy.
 2. Change the Docker argument list from `--env NAME=value` to `--env NAME` and
    pass the copied environment to `_run()`.
-3. In the benchmark harness, import and use `redact_backend_target()` before
-   displaying the DSN, matching `pytest_pg_main()`.
+3. In the benchmark harness, print a constant `[redacted]` marker rather than
+   passing the DSN through the output sink. CodeQL does not model the custom
+   sanitizer, and the benchmark does not need host or database details.
 4. Do not change the DSN returned to tests or the environment passed to backend
    subprocesses. Only the display and Docker command boundary change.
 

--- a/docs/plans/2026-07-12-code-scanning-alert-triage-plan.md
+++ b/docs/plans/2026-07-12-code-scanning-alert-triage-plan.md
@@ -1,0 +1,526 @@
+# Code Scanning Alert Remediation and Accepted-Risk Plan
+
+## Purpose
+
+This plan resolves the ten open GitHub code-scanning alerts without treating the
+OpenSSF Scorecard as a grade to maximize. It follows the repository's existing
+remediation pattern: verify each finding against the code, add regression evidence
+before changing behavior, fix concrete defects at the narrowest chokepoint, and
+record false positives or disproportionate controls as explicit exceptions.
+
+There are four outcomes:
+
+1. Fix the two real credential-output findings: CodeQL alerts `#28` and `#35`.
+2. Remove the four unlocked CI install paths: Scorecard alerts `#19`, `#25`,
+   `#32`, and `#33`.
+3. Dismiss CodeQL alert `#29` as a verified sanitizer false positive.
+4. Dismiss Scorecard alerts `#1`, `#20`, and `#22` as accepted solo-maintainer
+   policy choices, while adding a narrow green-CI gate for automated Dependabot
+   merges.
+
+The plan also restores trustworthy scanning before using a new scan as closure
+evidence. At planning time, the most recent successful alert-producing scan is
+for commit `9e48762415ddc4333120093dab18d6640b5dbda1`, while GitHub's `main` is
+`d0056c5cc937449aaac08e3fcd7cecb4da679139`. The live CodeQL workflow mixes
+`init` v4.36.3 with `analyze` v4.37.0 and fails before analysis. Open PR `#47`
+does not currently repair the repository: its CodeQL and Windows 3.14 checks are
+red.
+
+Assume the implementer is a skilled developer with no prior alert-triage context.
+Follow the tasks in order. Do not dismiss an alert before the evidence named here
+exists on the default branch.
+
+## Alert Disposition
+
+| Alert | Finding | Disposition | Reason |
+|---|---|---|---|
+| `#28` | `_run()` prints a command containing `POSTGRES_PASSWORD` | Fix | A test password can be supplied through the environment and is echoed into terminals or CI logs. |
+| `#35` | Backend benchmark prints a raw Postgres DSN | Fix | The benchmark is test-only, but its Docker password is configurable and should not be printed. |
+| `#29` | Redacted PG test DSN is reported as clear text | Dismiss: false positive | `redact_backend_target()` is a deliberate sanitizer with focused adversarial tests; CodeQL does not model it. |
+| `#19` | Packaging workflow runs `pip install build` | Fix | The install is redundant; packaging smoke already controls its build invocation. |
+| `#25`, `#32`, `#33` | Fuzz workflow upgrades pip and installs unlocked packages/project | Fix | Fuzz dependencies should come from the checked-in `uv.lock`, including hashes. |
+| `#1` | Branch protection is not maximal | Dismiss: won't fix | The active ruleset intentionally prevents deletion and non-fast-forward updates. Mandatory PRs and reviews are disproportionate for one maintainer. Automated merges receive a separate green-CI gate in this plan. |
+| `#20` | No approved changes among the last 30 | Dismiss: won't fix | Independent human approval cannot be required when the sole active maintainer authors the change. Revisit if a second active maintainer joins. |
+| `#22` | No OpenSSF Best Practices badge | Dismiss: won't fix | The badge measures formal multi-person OSS governance. Its low-risk maturity signal is not proportional to this project. |
+
+## Repository Precedents To Preserve
+
+- `docs/plans/2026-07-05-independent-review-fixes-plan.md` distinguishes real
+  findings from false positives and treats `_targets.py` as the single redaction
+  chokepoint.
+- `tests/test_target_redaction.py` uses adversarial observable-output assertions:
+  the secret must be absent and the useful target must remain.
+- `tests/test_dev_scripts.py` tests developer entry points through captured output
+  and small fakes at subprocess boundaries.
+- `.github/scripts/require_green_workflows.py` and
+  `tests/test_release_workflow_gate.py` already implement and test a fail-closed
+  sibling-workflow gate. Reuse them instead of adding a second GitHub API client.
+- `.github/dependabot.yml` and all workflow `uses:` references favor automated
+  updates, full SHA pins, and minimal job permissions.
+- `SECURITY.md` defines package, release, and supply-chain integrity as the
+  security scope. Alert dispositions should be evaluated against that scope.
+
+## Locked Decisions
+
+### Do not pursue a Scorecard 10/10
+
+The Scorecard remains useful as a generic control catalog, but its project model
+is not authoritative for this repository. Keep collecting and publishing the
+full Scorecard result. Do not filter SARIF, hide checks, add an OpenSSF badge, add
+nominal reviewers, or manufacture review evidence solely to improve the score.
+
+### Keep the current destructive-update ruleset
+
+Do not weaken or remove the active repository ruleset that blocks deletion and
+non-fast-forward updates to the default branch. Those controls are cheap and
+useful for a solo project. Do not add required PRs, required human approvals,
+code-owner review, or administrator review enforcement in this slice.
+
+### Gate automated merges without changing the human workflow
+
+The practical problem is not the absence of team-style review. It is that the
+current Dependabot job enables a merge without requiring sibling workflows to
+pass. Reuse `require_green_workflows.py` to require the `Test`, `Test Postgres
+Extension`, `Test Redis Extension`, and `CodeQL` workflows for the Dependabot PR
+head SHA, then merge. Human-authored updates remain governed by the current
+solo-maintainer workflow.
+
+### Keep credentials out of command arguments and output
+
+Do not teach generic `_run()` logging to guess which arbitrary arguments are
+secret. For the Docker password, pass `--env POSTGRES_PASSWORD` and place the
+value only in the subprocess environment. For DSNs intentionally displayed to a
+developer, call the existing `redact_backend_target()` chokepoint.
+
+### Use the repository lock, not hand-maintained requirements hashes
+
+Add Atheris to a root `uv` dependency group and regenerate `uv.lock`. Run fuzzing
+from a frozen sync. Do not add a parallel `requirements-fuzz.txt`, duplicate
+transitive hashes, or exact version pins in workflow YAML. Dependabot already
+maintains the root `uv` lock.
+
+## Task 0: Establish A Current Baseline
+
+### Goal
+
+Start implementation from the current GitHub default branch and preserve an
+auditable before-state.
+
+### Steps
+
+1. Fetch `origin`, confirm the working tree is clean, and create an implementation
+   branch from the current `origin/main`, not the planning checkout's stale
+   tracking ref.
+2. Record:
+
+   ```bash
+   git rev-parse HEAD
+   gh api --paginate \
+     '/repos/VanL/simplebroker/code-scanning/alerts?state=open&per_page=100' \
+     --jq '.[] | [.number, .tool.name, .rule.id, .most_recent_instance.commit_sha] | @tsv'
+   gh run list --repo VanL/simplebroker --branch main --limit 20
+   ```
+
+3. Run the focused baseline:
+
+   ```bash
+   uv run pytest -q -n 0 \
+     tests/test_target_redaction.py \
+     tests/test_dev_scripts.py \
+     tests/test_backend_benchmark_smoke.py \
+     tests/test_release_workflow.py \
+     tests/test_release_workflow_gate.py
+   uv run ruff check simplebroker/_scripts.py tests/backend_benchmark.py \
+     tests/test_dev_scripts.py tests/test_backend_benchmark_smoke.py \
+     tests/test_release_workflow.py .github/scripts/require_green_workflows.py
+   ```
+
+4. Save the exact messages and locations for alerts `#1`, `#19`, `#20`, `#22`,
+   `#25`, `#28`, `#29`, `#32`, `#33`, and `#35` in the implementation PR body.
+
+### Gate
+
+The implementer can explain which alert-producing scan is current, why the live
+CodeQL workflow fails, and why no alert has yet been dismissed.
+
+## Task 1: Restore Trustworthy CodeQL And Scorecard Runs
+
+### Primary files
+
+- `.github/workflows/codeql.yml`
+- `.github/workflows/scorecard.yml`
+- `.github/dependabot.yml`
+- `tests/test_release_workflow.py`
+
+### Tests first
+
+Add workflow-structure tests that fail on the current default branch:
+
+1. Every `github/codeql-action/*` reference in `codeql.yml` and `scorecard.yml`
+   uses one full SHA and one documented version.
+2. `codeql.yml` still grants only `contents: read` and job-local
+   `security-events: write`.
+3. `scorecard.yml` has `workflow_dispatch` in addition to push and schedule, so
+   the fixed/default-branch state can be verified immediately.
+4. Dependabot groups `github/codeql-action/*` updates into one PR so `init`,
+   `analyze`, and `upload-sarif` cannot be partially upgraded again.
+
+### Implementation
+
+1. Align `init`, `analyze`, and `upload-sarif` on the same current v4.37.0 full
+   SHA. Do not use a tag.
+2. Add a GitHub Actions dependency group for `github/codeql-action/*`.
+3. Add `workflow_dispatch` to the Scorecard workflow without changing its
+   schedule, permissions, artifact, or `publish_results` behavior.
+4. Supersede rather than merge PR `#47` once the replacement change is open.
+   Record the superseding PR in the close comment.
+
+### Gate
+
+```bash
+uv run pytest -q -n 0 tests/test_release_workflow.py
+uv run ruff check tests/test_release_workflow.py
+```
+
+On the implementation PR, `Analyze Python` must execute the query suite and
+upload results successfully. A configuration-error SARIF upload is not a pass.
+
+## Task 2: Remove Real Credential Output (`#28`, `#35`)
+
+### Primary files
+
+- `simplebroker/_scripts.py`
+- `tests/backend_benchmark.py`
+- `tests/test_dev_scripts.py`
+- `tests/test_backend_benchmark_smoke.py`
+
+### Red tests first
+
+1. In `tests/test_dev_scripts.py`, set a distinctive password such as
+   `command-output-secret`, invoke `_start_postgres_container()` through a small
+   `_run` fake, and assert:
+   - no command argument contains the secret;
+   - Docker receives `--env POSTGRES_PASSWORD` without `=<value>`;
+   - the subprocess environment contains the exact password;
+   - user/database variables remain present and container cleanup behavior is
+     unchanged.
+2. In `tests/test_backend_benchmark_smoke.py`, provision a fake Docker DSN with a
+   distinctive password, enter `_postgres_dsn_for_benchmark()`, and assert the
+   captured output contains `***` and never the secret.
+3. Keep `test_pytest_pg_main_redacts_dsn_password` green. It is the regression
+   evidence for the sink reported by false-positive alert `#29`.
+
+### Implementation
+
+1. In `_start_postgres_container()`, copy the process environment and set
+   `POSTGRES_PASSWORD`, `POSTGRES_USER`, and `POSTGRES_DB` in that copy.
+2. Change the Docker argument list from `--env NAME=value` to `--env NAME` and
+   pass the copied environment to `_run()`.
+3. In the benchmark harness, import and use `redact_backend_target()` before
+   displaying the DSN, matching `pytest_pg_main()`.
+4. Do not change the DSN returned to tests or the environment passed to backend
+   subprocesses. Only the display and Docker command boundary change.
+
+### Gates
+
+```bash
+uv run pytest -q -n 0 \
+  tests/test_target_redaction.py \
+  tests/test_dev_scripts.py \
+  tests/test_backend_benchmark_smoke.py
+uv run ruff check simplebroker/_scripts.py tests/backend_benchmark.py \
+  tests/test_dev_scripts.py tests/test_backend_benchmark_smoke.py
+uv run mypy simplebroker
+```
+
+Then run a Docker-backed smoke with a non-default test password and capture the
+log. The secret must not appear in the command echo, DSN display, or pytest
+output.
+
+## Task 3: Put Fuzzing And Packaging On The Lock (`#19`, `#25`, `#32`, `#33`)
+
+### Primary files
+
+- `pyproject.toml`
+- `uv.lock`
+- `.github/workflows/fuzz.yml`
+- `.github/workflows/test.yml`
+- `fuzz/fuzz_timestamp_validate.py`
+- `fuzz/fuzz_dump_load.py`
+- `tests/test_release_workflow.py`
+
+### Tests first
+
+Add workflow assertions that fail on the current files:
+
+1. `fuzz.yml` contains no `pip install`, `python -m pip`, or pip self-upgrade.
+2. The fuzz install is a frozen `uv` sync using the named fuzz dependency group.
+3. The fuzz command uses the already-synced environment and cannot update the
+   lock.
+4. The packaging job contains no standalone `pip install build` step.
+5. The root project declares Atheris in a fuzz-only dependency group; it is not a
+   runtime dependency or a normal developer requirement on unsupported systems.
+
+### Implementation
+
+1. Add a root `[dependency-groups]` entry named `fuzz` containing the supported
+   Atheris floor. Continue using the existing `dev` extra for Hypothesis and
+   pytest.
+2. Regenerate `uv.lock` and confirm Atheris artifacts and hashes are present.
+3. Replace the three pip commands in `fuzz.yml` with:
+   - `uv sync --frozen --extra dev --group fuzz` during installation;
+   - `uv run --frozen --no-sync ...` for the selected harness.
+4. Update both fuzz module usage comments to show the same locked `uv` commands.
+5. Delete the redundant `python -m pip install build` workflow step. Do not add a
+   new network install in its place. The existing packaging-smoke entry point is
+   responsible for its build tool invocation.
+6. If `packaging_smoke_main()` cannot run from a clean checkout after that
+   deletion, change its build invocation to consume the repository lock. Do not
+   reintroduce an unlocked pip install merely to make CI green.
+
+### Gates
+
+```bash
+uv lock --check
+uv sync --frozen --extra dev --group fuzz
+uv run --frozen --no-sync python -c \
+  'import atheris, hypothesis, pytest, simplebroker'
+uv run pytest -q -n 0 tests/test_release_workflow.py tests/test_dev_scripts.py
+uv run ./bin/packaging-smoke --python 3.11
+uv run ruff check fuzz tests/test_release_workflow.py simplebroker/_scripts.py
+```
+
+Run each fuzz harness with a short bounded duration, not the full scheduled
+15-minute budget, to prove startup, corpus loading, and imports.
+
+## Task 4: Gate Dependabot Without Adding Team-Scale Branch Rules
+
+### Primary files
+
+- `.github/workflows/dependabot.yml`
+- `.github/scripts/require_green_workflows.py` only if a real reuse gap is found
+- `tests/test_release_workflow.py`
+- `tests/test_release_workflow_gate.py` only if the shared gate changes
+
+### Tests first
+
+Add workflow assertions proving that the Dependabot job:
+
+1. has `actions: read`, `contents: write`, and `pull-requests: write`, with no
+   broader permission;
+2. checks out the repository before invoking the existing gate script;
+3. passes `${{ github.event.pull_request.head.sha }}` explicitly rather than the
+   synthetic pull-request merge SHA;
+4. requires `Test`, `Test Postgres Extension`, `Test Redis Extension`, and
+   `CodeQL`;
+5. merges only after the gate step and no longer calls `gh pr merge --auto`.
+
+### Implementation
+
+1. Reuse `.github/scripts/require_green_workflows.py` in the Dependabot job.
+   Do not copy its API/polling logic into YAML.
+2. Add `actions: read` to the job permissions.
+3. Gate only supported minor and patch updates, preserving the existing metadata
+   condition.
+4. After the gate returns success, run `gh pr merge --merge "$PR_URL"`.
+5. If any required workflow is missing, pending past the timeout, cancelled, or
+   red, fail without merging.
+
+The gate workflow itself is not in the required list, so there is no cycle.
+This control applies only to automated dependency changes and does not alter the
+default-branch ruleset or require human review.
+
+### Gates
+
+```bash
+uv run pytest -q -n 0 \
+  tests/test_release_workflow.py \
+  tests/test_release_workflow_gate.py
+uv run ruff check .github/scripts/require_green_workflows.py \
+  tests/test_release_workflow.py tests/test_release_workflow_gate.py
+```
+
+The implementation PR must also demonstrate one negative case: a test fixture or
+controlled run with a failed required workflow refuses to merge.
+
+## Task 5: Merge Fixes And Produce Fresh Analyzer Evidence
+
+### Steps
+
+1. Run all final local gates below.
+2. Open one focused PR. In its body, map every alert number to `fixed`, `false
+   positive`, or `accepted policy`, and link the exact evidence.
+3. Require the implementation PR's tests and CodeQL analysis to be green before
+   merge. Do not use the currently unsafe Dependabot auto-merge path.
+4. After merge, manually dispatch both workflows if a default-branch run was not
+   created automatically:
+
+   ```bash
+   gh workflow run CodeQL --repo VanL/simplebroker --ref main
+   gh workflow run 'OSSF Scorecard' --repo VanL/simplebroker --ref main
+   ```
+
+5. Wait for successful default-branch runs and confirm they analyzed the current
+   `main` SHA.
+6. Verify that `#28`, `#35`, `#19`, `#25`, `#32`, and `#33` moved to `fixed`.
+   Do not dismiss these to make the dashboard clean; a fix must close them.
+
+### Gate
+
+The current default-branch SHA has successful `CodeQL` and `OSSF Scorecard`
+runs, and all six implementation findings are closed as fixed.
+
+## Task 6: Record Deliberate Dismissals
+
+Dismiss only after Tasks 1 through 5 are complete, so the comments can cite
+evidence that exists on `main`.
+
+### Alert `#29`: false positive
+
+Use reason `false positive` and this substance in the comment:
+
+> The DSN is passed through `redact_backend_target()` before this print sink.
+> `tests/test_target_redaction.py` covers standard, reserved-character,
+> percent-encoded, malformed URL, and conninfo passwords, and
+> `test_pytest_pg_main_redacts_dsn_password` asserts the raw secret is absent from
+> observable output. The separate raw benchmark and Docker-command sinks were
+> fixed under alerts #35 and #28.
+
+### Alert `#1`: won't fix
+
+Use reason `won't fix` and this substance in the comment:
+
+> Accepted solo-maintainer policy. The active default-branch ruleset blocks
+> deletion and non-fast-forward updates without bypass. Mandatory PR-only
+> updates, independent approvals, and maximal branch protection are not
+> proportional for a one-maintainer repository. Automated Dependabot merges are
+> separately fail-closed on Test, Test Postgres Extension, Test Redis Extension,
+> and CodeQL in `.github/workflows/dependabot.yml`.
+
+### Alert `#20`: won't fix
+
+Use reason `won't fix` and this substance in the comment:
+
+> Accepted solo-maintainer constraint. Independent human approval cannot be
+> required when the sole active maintainer authors a change. CI, CodeQL, fuzzing,
+> release gates, and automated dependency updates remain in place. Revisit this
+> decision if a second active maintainer joins the project.
+
+### Alert `#22`: won't fix
+
+Use reason `won't fix` and this substance in the comment:
+
+> Accepted scope mismatch. The OpenSSF Best Practices badge measures formal OSS
+> governance and includes multi-person project assumptions that are not
+> proportional to this solo-maintained library. The repository retains a security
+> policy, least-privilege CI, CodeQL, fuzzing, lockfile updates, release gates,
+> trusted publishing, and artifact attestations without pursuing the badge.
+
+### API form
+
+Apply one alert at a time and read it back immediately:
+
+```bash
+gh api --method PATCH \
+  /repos/VanL/simplebroker/code-scanning/alerts/ALERT_NUMBER \
+  -f state=dismissed \
+  -f dismissed_reason='REASON' \
+  -f dismissed_comment='COMMENT'
+```
+
+Use `false positive` only for `#29`; use `won't fix` for the three policy
+exceptions. Do not label the Scorecard results false positives: their
+observations are accurate, but the prescribed controls do not fit this project.
+
+## Final Verification
+
+### Local gates
+
+```bash
+uv lock --check
+uv run pytest -q -n 0
+uv run ruff check .
+uv run ruff format --check .
+uv run mypy simplebroker \
+  extensions/simplebroker_pg/simplebroker_pg \
+  extensions/simplebroker_redis/simplebroker_redis
+uv run ./bin/packaging-smoke --python 3.11
+uv run ./bin/pytest-pg --fast
+uv run ./bin/pytest-redis --fast
+```
+
+Then run the default parallel core suite:
+
+```bash
+uv run pytest -q
+```
+
+### GitHub gates
+
+```bash
+gh api --paginate \
+  '/repos/VanL/simplebroker/code-scanning/alerts?state=open&per_page=100' \
+  --jq '.[] | [.number, .tool.name, .rule.id, .state] | @tsv'
+gh api --paginate \
+  '/repos/VanL/simplebroker/code-scanning/alerts?state=dismissed&per_page=100' \
+  --jq '.[] | [.number, .dismissed_reason, .dismissed_comment] | @tsv'
+gh api --paginate \
+  '/repos/VanL/simplebroker/code-scanning/alerts?state=fixed&per_page=100' \
+  --jq '.[] | [.number, .fixed_at, .most_recent_instance.commit_sha] | @tsv'
+```
+
+Expected final state:
+
+- Fixed: `#19`, `#25`, `#28`, `#32`, `#33`, `#35`.
+- Dismissed false positive: `#29`.
+- Dismissed won't fix: `#1`, `#20`, `#22`.
+- Open from this set: none.
+
+## Completion Evidence
+
+Fill this table during implementation. Do not mark a row complete from local
+tests alone when it requires GitHub state.
+
+| Slice | Status | Evidence |
+|---|---|---|
+| Current baseline captured | Pending | Record starting SHA, alert list, and failed CodeQL run. |
+| CodeQL versions aligned | Pending | PR run URL and successful default-branch run URL. |
+| Credential sinks fixed | Pending | Focused tests plus fixed alert URLs `#28` and `#35`. |
+| Locked CI installs | Pending | Lock diff, fuzz/packaging runs, fixed alert URLs `#19/#25/#32/#33`. |
+| Dependabot gate | Pending | Unit tests and one demonstrated fail-closed case. |
+| False-positive dismissal | Pending | Alert `#29` readback with reason and comment. |
+| Policy dismissals | Pending | Alerts `#1/#20/#22` readback with reasons and comments. |
+| Final analyzer state | Pending | Successful CodeQL/Scorecard runs on current `main`; zero open alerts from this set. |
+
+## Fresh-Eyes Review Checklist
+
+- Does any printed command, DSN, exception, or captured test output still contain
+  the configured Postgres password?
+- Was the password removed from the Docker argument vector, not merely replaced
+  in the visible echo?
+- Can the fuzz workflow run without resolving or changing `uv.lock`?
+- Did deleting `pip install build` leave packaging smoke reproducible from a
+  clean runner?
+- Can Dependabot merge while any one of the four required workflows is red,
+  cancelled, missing, or timed out?
+- Are CodeQL action updates grouped so a future partial version upgrade cannot
+  recreate the configuration error?
+- Do dismissal comments distinguish inaccurate analysis (`#29`) from accurate
+  observations with an intentionally rejected control (`#1/#20/#22`)?
+- Did any change weaken the existing no-delete/no-force-push ruleset?
+- Did anyone add badge work, nominal reviewers, SARIF filtering, or branch rules
+  solely to improve a score? If so, remove that work.
+
+## Non-Goals
+
+- No OpenSSF Best Practices badge application.
+- No attempt to reach a Scorecard 10/10.
+- No required human review, CODEOWNERS approval, or second nominal maintainer.
+- No mandatory PR workflow for human-authored changes.
+- No removal or weakening of the current deletion/non-fast-forward protection.
+- No custom CodeQL model for `redact_backend_target()` in this slice.
+- No separate requirements file or manually maintained transitive hash list.
+- No refactor of the general subprocess runner beyond the password-bearing Docker
+  call site.
+- No dismissal of a concrete finding that can be closed by a code or workflow
+  fix.

--- a/extensions/simplebroker_pg/uv.lock
+++ b/extensions/simplebroker_pg/uv.lock
@@ -181,6 +181,9 @@ requires-dist = [
 ]
 provides-extras = ["dev", "pg", "redis"]
 
+[package.metadata.requires-dev]
+fuzz = [{ name = "atheris", specifier = ">=2.3.0" }]
+
 [[package]]
 name = "simplebroker-pg"
 version = "3.2.1"

--- a/extensions/simplebroker_redis/uv.lock
+++ b/extensions/simplebroker_redis/uv.lock
@@ -121,6 +121,9 @@ requires-dist = [
 ]
 provides-extras = ["dev", "pg", "redis"]
 
+[package.metadata.requires-dev]
+fuzz = [{ name = "atheris", specifier = ">=2.3.0" }]
+
 [[package]]
 name = "simplebroker-redis"
 version = "3.2.1"

--- a/fuzz/fuzz_dump_load.py
+++ b/fuzz/fuzz_dump_load.py
@@ -13,8 +13,8 @@ with plain pytest.
 
 Run (Linux only — Atheris does not build on macOS arm64):
 
-    pip install atheris hypothesis pytest && pip install -e .
-    python fuzz/fuzz_dump_load.py fuzz/corpus/dump_load
+    uv sync --frozen --extra dev --group fuzz
+    uv run --frozen --no-sync python fuzz/fuzz_dump_load.py fuzz/corpus/dump_load
 
 Any libFuzzer flags (-max_total_time, -runs, ...) pass through. See
 .github/workflows/fuzz.yml for the scheduled run.

--- a/fuzz/fuzz_timestamp_validate.py
+++ b/fuzz/fuzz_timestamp_validate.py
@@ -11,8 +11,9 @@ replay with plain pytest.
 
 Run (Linux only — Atheris does not build on macOS arm64):
 
-    pip install atheris hypothesis pytest && pip install -e .
-    python fuzz/fuzz_timestamp_validate.py fuzz/corpus/timestamp_validate
+    uv sync --frozen --extra dev --group fuzz
+    uv run --frozen --no-sync python fuzz/fuzz_timestamp_validate.py \
+        fuzz/corpus/timestamp_validate
 
 Any libFuzzer flags (-max_total_time, -runs, ...) pass through. See
 .github/workflows/fuzz.yml for the scheduled run.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,11 @@ redis = [
     "simplebroker-redis>=3.2.1",
 ]
 
+[dependency-groups]
+fuzz = [
+    "atheris>=2.3.0; sys_platform == 'linux' and platform_machine == 'x86_64'",
+]
+
 [project.scripts]
 broker = "simplebroker.cli:main"
 simplebroker = "simplebroker.cli:main"
@@ -63,6 +68,9 @@ Homepage = "https://github.com/VanL/simplebroker"
 Documentation = "https://github.com/VanL/simplebroker#readme"
 Repository = "https://github.com/VanL/simplebroker.git"
 Issues = "https://github.com/VanL/simplebroker/issues"
+
+[tool.uv]
+default-groups = []
 
 [tool.uv.sources]
 simplebroker-pg = { path = "./extensions/simplebroker_pg", editable = true }

--- a/simplebroker/_scripts.py
+++ b/simplebroker/_scripts.py
@@ -159,6 +159,14 @@ def _start_postgres_container() -> tuple[str, str]:
     """Start the temporary Postgres container and return its name and DSN."""
 
     container_name = f"simplebroker-pg-test-{os.getpid()}-{uuid.uuid4().hex[:8]}"
+    container_env = os.environ.copy()
+    container_env.update(
+        {
+            "POSTGRES_PASSWORD": POSTGRES_PASSWORD,
+            "POSTGRES_USER": POSTGRES_USER,
+            "POSTGRES_DB": POSTGRES_DB,
+        }
+    )
     _run(
         [
             "docker",
@@ -168,16 +176,17 @@ def _start_postgres_container() -> tuple[str, str]:
             "--name",
             container_name,
             "--env",
-            f"POSTGRES_PASSWORD={POSTGRES_PASSWORD}",
+            "POSTGRES_PASSWORD",
             "--env",
-            f"POSTGRES_USER={POSTGRES_USER}",
+            "POSTGRES_USER",
             "--env",
-            f"POSTGRES_DB={POSTGRES_DB}",
+            "POSTGRES_DB",
             "--publish-all",
             POSTGRES_IMAGE,
             "-c",
             "max_connections=300",
         ],
+        env=container_env,
         capture_output=True,
     )
     try:

--- a/tests/backend_benchmark.py
+++ b/tests/backend_benchmark.py
@@ -33,6 +33,7 @@ from simplebroker._scripts import (
     _start_valkey_container,
     _verify_postgres_test_dsn,
 )
+from simplebroker._targets import redact_backend_target
 
 if __package__ in {None, ""}:
     REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -449,7 +450,10 @@ def _postgres_dsn_for_benchmark(settings: BenchmarkSettings):
     container_name: str | None = None
     try:
         container_name, dsn = _start_postgres_container()
-        print(f"Postgres benchmark DSN: {dsn}", flush=True)
+        print(
+            f"Postgres benchmark DSN: {redact_backend_target(dsn)}",
+            flush=True,
+        )
         _verify_postgres_test_dsn(dsn)
         yield dsn
     finally:

--- a/tests/backend_benchmark.py
+++ b/tests/backend_benchmark.py
@@ -33,7 +33,6 @@ from simplebroker._scripts import (
     _start_valkey_container,
     _verify_postgres_test_dsn,
 )
-from simplebroker._targets import redact_backend_target
 
 if __package__ in {None, ""}:
     REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -450,10 +449,7 @@ def _postgres_dsn_for_benchmark(settings: BenchmarkSettings):
     container_name: str | None = None
     try:
         container_name, dsn = _start_postgres_container()
-        print(
-            f"Postgres benchmark DSN: {redact_backend_target(dsn)}",
-            flush=True,
-        )
+        print("Postgres benchmark DSN: [redacted]", flush=True)
         _verify_postgres_test_dsn(dsn)
         yield dsn
     finally:

--- a/tests/test_backend_benchmark_smoke.py
+++ b/tests/test_backend_benchmark_smoke.py
@@ -132,6 +132,42 @@ def test_postgres_benchmark_docker_mode_manages_container(
     assert calls[-1] == ("cleanup-container", "pg-container")
 
 
+def test_postgres_benchmark_redacts_provisioned_dsn(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    secret = "benchmark-output-secret"
+    dsn = f"postgresql://postgres:{secret}@127.0.0.1:5432/test"
+
+    monkeypatch.setattr(
+        backend_benchmark,
+        "_start_postgres_container",
+        lambda: ("pg-container", dsn),
+    )
+    monkeypatch.setattr(
+        backend_benchmark,
+        "_verify_postgres_test_dsn",
+        lambda value: None,
+    )
+    monkeypatch.setattr(
+        backend_benchmark,
+        "_cleanup_container",
+        lambda value: None,
+    )
+    settings = BenchmarkSettings(
+        backends=(backend_benchmark.POSTGRES_TEST_BACKEND,),
+        workloads=("write_single",),
+        pg_docker=True,
+    )
+
+    with backend_benchmark._postgres_dsn_for_benchmark(settings) as provisioned:
+        assert provisioned == dsn
+
+    output = capsys.readouterr().out
+    assert "postgresql://postgres:***@127.0.0.1:5432/test" in output
+    assert secret not in output
+
+
 def test_postgres_benchmark_docker_mode_cleans_up_after_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_backend_benchmark_smoke.py
+++ b/tests/test_backend_benchmark_smoke.py
@@ -164,7 +164,7 @@ def test_postgres_benchmark_redacts_provisioned_dsn(
         assert provisioned == dsn
 
     output = capsys.readouterr().out
-    assert "postgresql://postgres:***@127.0.0.1:5432/test" in output
+    assert output == "Postgres benchmark DSN: [redacted]\n"
     assert secret not in output
 
 

--- a/tests/test_dev_scripts.py
+++ b/tests/test_dev_scripts.py
@@ -372,6 +372,49 @@ def test_start_postgres_cleans_up_when_readiness_fails(
     assert cleanup_calls[0].startswith("simplebroker-pg-test-")
 
 
+def test_start_postgres_keeps_password_out_of_docker_command(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+    password = "command-output-secret"
+
+    monkeypatch.setattr(_scripts, "POSTGRES_PASSWORD", password)
+    monkeypatch.setattr(_scripts, "POSTGRES_USER", "test-user")
+    monkeypatch.setattr(_scripts, "POSTGRES_DB", "test-db")
+    monkeypatch.setattr(_scripts, "_wait_for_postgres", lambda name: "32786")
+
+    def fake_run(
+        cmd: list[str],
+        *,
+        cwd: Path = _scripts.ROOT,
+        env: dict[str, str] | None = None,
+        capture_output: bool = False,
+    ) -> subprocess.CompletedProcess[str]:
+        captured.update(cmd=cmd, env=env, capture_output=capture_output)
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(_scripts, "_run", fake_run)
+
+    _, dsn = _scripts._start_postgres_container()
+
+    command = captured["cmd"]
+    assert isinstance(command, list)
+    assert all(password not in arg for arg in command)
+    assert [
+        command[index + 1] for index, arg in enumerate(command) if arg == "--env"
+    ] == [
+        "POSTGRES_PASSWORD",
+        "POSTGRES_USER",
+        "POSTGRES_DB",
+    ]
+    environment = captured["env"]
+    assert isinstance(environment, dict)
+    assert environment["POSTGRES_PASSWORD"] == password
+    assert environment["POSTGRES_USER"] == "test-user"
+    assert environment["POSTGRES_DB"] == "test-db"
+    assert password in dsn
+
+
 def test_start_valkey_cleans_up_when_readiness_fails(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -1,3 +1,5 @@
+import re
+import tomllib
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -5,6 +7,99 @@ ROOT = Path(__file__).resolve().parents[1]
 
 def _workflow_text(path: str) -> str:
     return (ROOT / ".github" / "workflows" / path).read_text(encoding="utf-8")
+
+
+def test_codeql_actions_use_one_full_sha() -> None:
+    references: list[str] = []
+    for workflow_path in ("codeql.yml", "scorecard.yml"):
+        references.extend(
+            re.findall(
+                r"uses: github/codeql-action/[^@]+@([0-9a-f]+)",
+                _workflow_text(workflow_path),
+            )
+        )
+
+    assert references
+    assert all(len(reference) == 40 for reference in references)
+    assert len(set(references)) == 1
+
+
+def test_scorecard_can_be_dispatched_for_fresh_default_branch_evidence() -> None:
+    workflow_text = _workflow_text("scorecard.yml")
+
+    assert "workflow_dispatch:" in workflow_text
+
+
+def test_dependabot_groups_codeql_action_updates() -> None:
+    dependabot_text = (ROOT / ".github" / "dependabot.yml").read_text(encoding="utf-8")
+    github_actions = dependabot_text.split('- package-ecosystem: "github-actions"', 1)[
+        1
+    ]
+
+    assert "groups:" in github_actions
+    assert "codeql-actions:" in github_actions
+    assert '- "github/codeql-action/*"' in github_actions
+
+
+def test_codeql_permissions_remain_job_scoped() -> None:
+    workflow_text = _workflow_text("codeql.yml")
+
+    assert workflow_text.count("contents: read") == 2
+    assert workflow_text.count("security-events: write") == 1
+    assert "permissions: write-all" not in workflow_text
+
+
+def test_fuzz_workflow_uses_frozen_uv_environment() -> None:
+    workflow_text = _workflow_text("fuzz.yml")
+
+    assert "pip install" not in workflow_text
+    assert "python -m pip" not in workflow_text
+    assert "uses: astral-sh/setup-uv@" in workflow_text
+    assert "uv sync --frozen --extra dev --group fuzz" in workflow_text
+    assert "uv run --frozen --no-sync python fuzz/fuzz_${{ matrix.harness }}.py" in (
+        workflow_text
+    )
+
+
+def test_fuzz_dependency_group_is_opt_in() -> None:
+    pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+
+    assert pyproject["dependency-groups"]["fuzz"] == [
+        "atheris>=2.3.0; sys_platform == 'linux' and platform_machine == 'x86_64'"
+    ]
+    assert pyproject["tool"]["uv"]["default-groups"] == []
+
+
+def test_packaging_workflow_has_no_redundant_pip_install() -> None:
+    workflow_text = _workflow_text("test.yml")
+    packaging_section = workflow_text.split("  packaging:", 1)[1].split(
+        "  coverage:", 1
+    )[0]
+
+    assert "pip install" not in packaging_section
+    assert "./bin/packaging-smoke --python 3.11" in packaging_section
+
+
+def test_dependabot_merges_only_after_required_workflows_are_green() -> None:
+    workflow_text = _workflow_text("dependabot.yml")
+
+    assert "actions: read" in workflow_text
+    assert "contents: write" in workflow_text
+    assert "pull-requests: write" in workflow_text
+    assert "uses: actions/checkout@" in workflow_text
+    assert "python .github/scripts/require_green_workflows.py" in workflow_text
+    assert '--sha "${{ github.event.pull_request.head.sha }}"' in workflow_text
+    for required_workflow in (
+        "Test",
+        "Test Postgres Extension",
+        "Test Redis Extension",
+        "CodeQL",
+    ):
+        assert f'--workflow "{required_workflow}"' in workflow_text
+    assert "gh pr merge --auto" not in workflow_text
+    assert workflow_text.index("require_green_workflows.py") < workflow_text.index(
+        "gh pr merge --merge"
+    )
 
 
 def test_release_gate_workflows_publish_from_top_level_gate() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -75,6 +75,16 @@ wheels = [
 ]
 
 [[package]]
+name = "atheris"
+version = "3.1.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/88/fd6ad595dafa9c7ce56dbfcaff0c7244988dac3af86c771166c6516ccf6b/atheris-3.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ec5e11f21a4c197fe91f7aea2b2de88e623c73a21fc07b105ac6329a1588457b", size = 36875908, upload-time = "2026-06-17T00:04:01.104Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/18/e19718c384fd7d801d0da7485407daef9af6194b6d8c8818175bec5efec6/atheris-3.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f8a9f51ce8369026e8eb7b7174835e8c4c85a1a6db5d9add36c15100779d2a39", size = 36800563, upload-time = "2026-06-17T00:04:04.559Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/ff/ae7a5bfe99033e510bea4ed09934e636d93777317a48147369bc0dc2b71f/atheris-3.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:315a0b5c819852b1ffe1ca72efc389c7724881f2c33e4aacb8c6bcec49bd5011", size = 36772569, upload-time = "2026-06-17T00:04:07.702Z" },
+]
+
+[[package]]
 name = "build"
 version = "1.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -647,6 +657,11 @@ redis = [
     { name = "simplebroker-redis" },
 ]
 
+[package.dev-dependencies]
+fuzz = [
+    { name = "atheris", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "aiosqlite", marker = "extra == 'dev'", specifier = ">=0.22.1" },
@@ -666,6 +681,9 @@ requires-dist = [
     { name = "simplebroker-redis", marker = "extra == 'redis'", editable = "extensions/simplebroker_redis" },
 ]
 provides-extras = ["dev", "pg", "redis"]
+
+[package.metadata.requires-dev]
+fuzz = [{ name = "atheris", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'", specifier = ">=2.3.0" }]
 
 [[package]]
 name = "simplebroker-pg"


### PR DESCRIPTION
## What changed

- remove PostgreSQL test credentials from Docker command arguments and redact benchmark DSN output
- run fuzz dependencies from the checked-in uv lock and remove the redundant packaging pip install
- align CodeQL actions, group future CodeQL dependency updates, and add manual Scorecard dispatch
- gate Dependabot merges on successful Test, Test Postgres Extension, Test Redis Extension, and CodeQL workflows
- add the executable remediation and accepted-risk plan

## Alert disposition

- fixes #19, #25, #28, #32, #33, and #35
- preserves evidence for dismissing #29 as a custom-sanitizer false positive
- documents proportional solo-maintainer reasons for dismissing #1, #20, and #22 as accepted policy choices

## Root cause and impact

The Docker helper embedded a configurable password in the command vector, the benchmark printed the raw DSN, and CI had several live pip resolution paths. Separately, partial Dependabot upgrades left CodeQL actions on incompatible versions, while automated merges were not gated on sibling workflow conclusions.

The changes keep the existing human maintenance and branch rules intact. Only automated Dependabot merges gain a fail-closed CI gate.

## Validation

- full serial core suite passed
- default parallel core suite passed
- PostgreSQL: 850 shared tests and 101 extension tests passed
- Redis: 843 shared tests and 79 extension tests passed
- packaging smoke passed on Python 3.11
- Ruff lint and format checks passed for all 259 Python files
- mypy passed across core and both extensions
- focused alert and workflow regression suite: 80 tests passed
