### PR TITLE
Harden locked CI and release builds

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -13,6 +13,9 @@ on:
 permissions:
   contents: read
 
+env:
+  UV_VERSION: "0.11.28"
+
 jobs:
   fuzz:
     runs-on: ubuntu-latest
@@ -33,6 +36,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
+          version: ${{ env.UV_VERSION }}
           enable-cache: true
           cache-dependency-glob: |
             pyproject.toml

--- a/.github/workflows/release-gate-pg.yml
+++ b/.github/workflows/release-gate-pg.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  UV_VERSION: "0.11.11"
+  UV_VERSION: "0.11.28"
   PACKAGE_NAME: simplebroker-pg
   PACKAGE_DIR: extensions/simplebroker_pg
 
@@ -100,7 +100,7 @@ jobs:
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           version: ${{ env.UV_VERSION }}
-          enable-cache: true
+          enable-cache: false
 
       - name: Verify checked out commit matches tested release commit
         run: |
@@ -125,10 +125,12 @@ jobs:
               raise SystemExit(f"tag {tag} != pyproject version {package_version}")
           PY
 
+      - name: Install locked build frontend
+        run: uv sync --frozen --group release
+
       - name: Build package
-        working-directory: ${{ env.PACKAGE_DIR }}
         run: |
-          uv build
+          uv run --frozen --no-sync python -m build --no-isolation "${PACKAGE_DIR}"
 
       - name: Generate artifact attestation
         id: attest

--- a/.github/workflows/release-gate-redis.yml
+++ b/.github/workflows/release-gate-redis.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  UV_VERSION: "0.11.11"
+  UV_VERSION: "0.11.28"
   PACKAGE_NAME: simplebroker-redis
   PACKAGE_DIR: extensions/simplebroker_redis
 
@@ -100,7 +100,7 @@ jobs:
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           version: ${{ env.UV_VERSION }}
-          enable-cache: true
+          enable-cache: false
 
       - name: Verify checked out commit matches tested release commit
         run: |
@@ -125,10 +125,12 @@ jobs:
               raise SystemExit(f"tag {tag} != pyproject version {package_version}")
           PY
 
+      - name: Install locked build frontend
+        run: uv sync --frozen --group release
+
       - name: Build package
-        working-directory: ${{ env.PACKAGE_DIR }}
         run: |
-          uv build
+          uv run --frozen --no-sync python -m build --no-isolation "${PACKAGE_DIR}"
 
       - name: Generate artifact attestation
         id: attest

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  UV_VERSION: "0.11.11"
+  UV_VERSION: "0.11.28"
   PACKAGE_NAME: simplebroker
   PACKAGE_DIR: .
 
@@ -85,7 +85,7 @@ jobs:
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           version: ${{ env.UV_VERSION }}
-          enable-cache: true
+          enable-cache: false
 
       - name: Verify checked out commit matches tested release commit
         run: |
@@ -110,10 +110,12 @@ jobs:
               raise SystemExit(f"tag {tag} != pyproject version {package_version}")
           PY
 
+      - name: Install locked build frontend
+        run: uv sync --frozen --group release
+
       - name: Build package
-        working-directory: ${{ env.PACKAGE_DIR }}
         run: |
-          uv build
+          uv run --frozen --no-sync python -m build --no-isolation "${PACKAGE_DIR}"
 
       - name: Generate artifact attestation
         id: attest

--- a/.github/workflows/test-pg-extension.yml
+++ b/.github/workflows/test-pg-extension.yml
@@ -10,6 +10,9 @@ on:
 permissions:
   contents: read
 
+env:
+  UV_VERSION: "0.11.28"
+
 jobs:
   test-pg:
     strategy:
@@ -29,6 +32,7 @@ jobs:
     - name: Install uv
       uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990
       with:
+        version: ${{ env.UV_VERSION }}
         enable-cache: true
         cache-dependency-glob: |
           pyproject.toml
@@ -36,9 +40,12 @@ jobs:
           extensions/simplebroker_pg/pyproject.toml
           extensions/simplebroker_pg/uv.lock
 
+    - name: Install dependencies
+      run: uv sync --frozen --extra dev --extra pg
+
     - name: Run PG-backed test suites
       run: |
-        uv run ./bin/pytest-pg
+        uv run --frozen --no-sync ./bin/pytest-pg
 
   lint:
     runs-on: ubuntu-latest
@@ -53,6 +60,7 @@ jobs:
     - name: Install uv
       uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990
       with:
+        version: ${{ env.UV_VERSION }}
         enable-cache: true
         cache-dependency-glob: |
           pyproject.toml
@@ -60,15 +68,18 @@ jobs:
           extensions/simplebroker_pg/pyproject.toml
           extensions/simplebroker_pg/uv.lock
 
+    - name: Install dependencies
+      run: uv sync --frozen --extra dev --extra pg
+
     - name: Run extension linting with ruff
       run: |
-        uv run --extra dev ruff check extensions/simplebroker_pg/simplebroker_pg extensions/simplebroker_pg/tests
+        uv run --frozen --no-sync ruff check extensions/simplebroker_pg/simplebroker_pg extensions/simplebroker_pg/tests
 
     - name: Check extension formatting with ruff
       run: |
-        uv run --extra dev ruff format --check extensions/simplebroker_pg/simplebroker_pg extensions/simplebroker_pg/tests
+        uv run --frozen --no-sync ruff format --check extensions/simplebroker_pg/simplebroker_pg extensions/simplebroker_pg/tests
 
     - name: Type check extension with mypy
       run: |
         mapfile -t pg_test_files < <(find extensions/simplebroker_pg/tests -type f -name '*.py' -not -path '*/__pycache__/*' | sort)
-        uv run --extra dev mypy extensions/simplebroker_pg/simplebroker_pg "${pg_test_files[@]}" --config-file pyproject.toml
+        uv run --frozen --no-sync mypy extensions/simplebroker_pg/simplebroker_pg "${pg_test_files[@]}" --config-file pyproject.toml

--- a/.github/workflows/test-redis-extension.yml
+++ b/.github/workflows/test-redis-extension.yml
@@ -10,6 +10,9 @@ on:
 permissions:
   contents: read
 
+env:
+  UV_VERSION: "0.11.28"
+
 jobs:
   test-redis:
     strategy:
@@ -29,6 +32,7 @@ jobs:
     - name: Install uv
       uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990
       with:
+        version: ${{ env.UV_VERSION }}
         enable-cache: true
         cache-dependency-glob: |
           pyproject.toml
@@ -36,9 +40,12 @@ jobs:
           extensions/simplebroker_redis/pyproject.toml
           extensions/simplebroker_redis/uv.lock
 
+    - name: Install dependencies
+      run: uv sync --frozen --extra dev --extra redis
+
     - name: Run Redis-backed test suites
       run: |
-        uv run ./bin/pytest-redis
+        uv run --frozen --no-sync ./bin/pytest-redis
 
   lint:
     runs-on: ubuntu-latest
@@ -53,6 +60,7 @@ jobs:
     - name: Install uv
       uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990
       with:
+        version: ${{ env.UV_VERSION }}
         enable-cache: true
         cache-dependency-glob: |
           pyproject.toml
@@ -60,15 +68,18 @@ jobs:
           extensions/simplebroker_redis/pyproject.toml
           extensions/simplebroker_redis/uv.lock
 
+    - name: Install dependencies
+      run: uv sync --frozen --extra dev --extra redis
+
     - name: Run extension linting with ruff
       run: |
-        uv run --extra dev ruff check extensions/simplebroker_redis/simplebroker_redis extensions/simplebroker_redis/tests
+        uv run --frozen --no-sync ruff check extensions/simplebroker_redis/simplebroker_redis extensions/simplebroker_redis/tests
 
     - name: Check extension formatting with ruff
       run: |
-        uv run --extra dev ruff format --check extensions/simplebroker_redis/simplebroker_redis extensions/simplebroker_redis/tests
+        uv run --frozen --no-sync ruff format --check extensions/simplebroker_redis/simplebroker_redis extensions/simplebroker_redis/tests
 
     - name: Type check extension with mypy
       run: |
         mapfile -t redis_test_files < <(find extensions/simplebroker_redis/tests -type f -name '*.py' -not -path '*/__pycache__/*' | sort)
-        uv run --extra dev mypy extensions/simplebroker_redis/simplebroker_redis "${redis_test_files[@]}" --config-file pyproject.toml
+        uv run --frozen --no-sync mypy extensions/simplebroker_redis/simplebroker_redis "${redis_test_files[@]}" --config-file pyproject.toml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,36 @@ on:
 permissions:
   contents: read
 
+env:
+  UV_VERSION: "0.11.28"
+
 jobs:
+  locks:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+
+    - name: Set up Python
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
+      with:
+        python-version: "3.12"
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990
+      with:
+        version: ${{ env.UV_VERSION }}
+        enable-cache: true
+        cache-dependency-glob: |
+          pyproject.toml
+          uv.lock
+          extensions/simplebroker_pg/pyproject.toml
+          extensions/simplebroker_pg/uv.lock
+          extensions/simplebroker_redis/pyproject.toml
+          extensions/simplebroker_redis/uv.lock
+
+    - name: Check uv policy and lockfiles
+      run: python bin/bump_uv.py --check
+
   test:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -36,6 +65,7 @@ jobs:
     - name: Install uv
       uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990
       with:
+        version: ${{ env.UV_VERSION }}
         enable-cache: true
         cache-dependency-glob: |
           pyproject.toml
@@ -47,22 +77,22 @@ jobs:
 
     - name: Install dependencies
       run: |
-        uv pip install --system -e ".[dev]"
+        uv sync --frozen --extra dev
 
     - name: Run tests with pytest
       run: |
-        pytest -v --tb=short -m "not benchmark" --override-ini="addopts=-ra -q --strict-markers -n auto --dist loadgroup"
+        uv run --frozen --no-sync pytest -v --tb=short -m "not benchmark" --override-ini="addopts=-ra -q --strict-markers -n auto --dist loadgroup"
 
     - name: Run phaselock fallback-path gate
       env:
         PHASELOCK_ENABLE_XATTRS: "0"
       run: |
-        pytest -v --tb=short -m "not benchmark" --override-ini="addopts=-ra -q --strict-markers -n auto --dist loadgroup" tests/test_phaselock.py tests/test_runner_validation.py tests/test_runner_error_handling.py tests/test_queue_config_defaults.py tests/test_sqlite_setup_contention.py
+        uv run --frozen --no-sync pytest -v --tb=short -m "not benchmark" --override-ini="addopts=-ra -q --strict-markers -n auto --dist loadgroup" tests/test_phaselock.py tests/test_runner_validation.py tests/test_runner_error_handling.py tests/test_queue_config_defaults.py tests/test_sqlite_setup_contention.py
 
     - name: Test CLI installation
       run: |
-        broker --version
-        simplebroker --version
+        uv run --frozen --no-sync broker --version
+        uv run --frozen --no-sync simplebroker --version
 
   lint:
     runs-on: ubuntu-latest
@@ -77,6 +107,7 @@ jobs:
     - name: Install uv
       uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990
       with:
+        version: ${{ env.UV_VERSION }}
         enable-cache: true
         cache-dependency-glob: |
           pyproject.toml
@@ -88,23 +119,23 @@ jobs:
 
     - name: Install dependencies
       run: |
-        uv pip install --system -e ".[dev]"
+        uv sync --frozen --extra dev --extra pg --extra redis
 
     - name: Run linting with ruff
       run: |
-        ruff check simplebroker tests bin .github/scripts extensions/simplebroker_pg/simplebroker_pg extensions/simplebroker_pg/tests extensions/simplebroker_redis/simplebroker_redis extensions/simplebroker_redis/tests
+        uv run --frozen --no-sync ruff check simplebroker tests bin .github/scripts extensions/simplebroker_pg/simplebroker_pg extensions/simplebroker_pg/tests extensions/simplebroker_redis/simplebroker_redis extensions/simplebroker_redis/tests
 
     - name: Check formatting with ruff
       run: |
-        ruff format --check simplebroker tests bin .github/scripts extensions/simplebroker_pg/simplebroker_pg extensions/simplebroker_pg/tests extensions/simplebroker_redis/simplebroker_redis extensions/simplebroker_redis/tests
+        uv run --frozen --no-sync ruff format --check simplebroker tests bin .github/scripts extensions/simplebroker_pg/simplebroker_pg extensions/simplebroker_pg/tests extensions/simplebroker_redis/simplebroker_redis extensions/simplebroker_redis/tests
 
     - name: Type check with mypy
       run: |
         mapfile -t pg_test_files < <(find extensions/simplebroker_pg/tests -type f -name '*.py' -not -path '*/__pycache__/*' | sort)
         mapfile -t redis_test_files < <(find extensions/simplebroker_redis/tests -type f -name '*.py' -not -path '*/__pycache__/*' | sort)
-        mypy simplebroker bin/release.py extensions/simplebroker_pg/simplebroker_pg extensions/simplebroker_redis/simplebroker_redis --config-file pyproject.toml
-        mypy extensions/simplebroker_pg/simplebroker_pg "${pg_test_files[@]}" --config-file pyproject.toml
-        mypy extensions/simplebroker_redis/simplebroker_redis "${redis_test_files[@]}" --config-file pyproject.toml
+        uv run --frozen --no-sync mypy simplebroker bin/release.py extensions/simplebroker_pg/simplebroker_pg extensions/simplebroker_redis/simplebroker_redis --config-file pyproject.toml
+        uv run --frozen --no-sync mypy extensions/simplebroker_pg/simplebroker_pg "${pg_test_files[@]}" --config-file pyproject.toml
+        uv run --frozen --no-sync mypy extensions/simplebroker_redis/simplebroker_redis "${redis_test_files[@]}" --config-file pyproject.toml
 
   packaging:
     runs-on: ubuntu-latest
@@ -119,6 +150,7 @@ jobs:
     - name: Install uv
       uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990
       with:
+        version: ${{ env.UV_VERSION }}
         enable-cache: true
         cache-dependency-glob: |
           pyproject.toml
@@ -130,7 +162,8 @@ jobs:
 
     - name: Run packaging smoke
       run: |
-        uv run ./bin/packaging-smoke --python 3.11
+        uv sync --frozen --extra dev
+        uv run --frozen --no-sync ./bin/packaging-smoke --python 3.11
 
   coverage:
     runs-on: ubuntu-latest
@@ -145,6 +178,7 @@ jobs:
     - name: Install uv
       uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990
       with:
+        version: ${{ env.UV_VERSION }}
         enable-cache: true
         cache-dependency-glob: |
           pyproject.toml
@@ -156,7 +190,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        uv pip install --system -e ".[dev]"
+        uv sync --frozen --extra dev --extra pg --extra redis
 
     - name: Run tests with coverage
       env:
@@ -164,13 +198,13 @@ jobs:
         COVERAGE_PROCESS_START: ${{ github.workspace }}/pyproject.toml
         COVERAGE_FILE: ${{ github.workspace }}/.coverage
       run: |
-        uv run coverage erase
-        uv run pytest --cov=simplebroker --cov=extensions/simplebroker_pg/simplebroker_pg --cov=extensions/simplebroker_redis/simplebroker_redis --cov-append --cov-report= -m "not benchmark"
-        PYTEST_ADDOPTS= uv run ./bin/pytest-pg --fast --cov=simplebroker --cov=extensions/simplebroker_pg/simplebroker_pg --cov=extensions/simplebroker_redis/simplebroker_redis --cov-append --cov-report=
-        PYTEST_ADDOPTS= uv run ./bin/pytest-redis --fast --cov=simplebroker --cov=extensions/simplebroker_pg/simplebroker_pg --cov=extensions/simplebroker_redis/simplebroker_redis --cov-append --cov-report=
-        uv run python .github/scripts/combine_coverage.py
-        uv run coverage report --show-missing
-        uv run coverage xml
+        uv run --frozen --no-sync coverage erase
+        uv run --frozen --no-sync pytest --cov=simplebroker --cov=extensions/simplebroker_pg/simplebroker_pg --cov=extensions/simplebroker_redis/simplebroker_redis --cov-append --cov-report= -m "not benchmark"
+        PYTEST_ADDOPTS= uv run --frozen --no-sync ./bin/pytest-pg --fast --cov=simplebroker --cov=extensions/simplebroker_pg/simplebroker_pg --cov=extensions/simplebroker_redis/simplebroker_redis --cov-append --cov-report=
+        PYTEST_ADDOPTS= uv run --frozen --no-sync ./bin/pytest-redis --fast --cov=simplebroker --cov=extensions/simplebroker_pg/simplebroker_pg --cov=extensions/simplebroker_redis/simplebroker_redis --cov-append --cov-report=
+        uv run --frozen --no-sync python .github/scripts/combine_coverage.py
+        uv run --frozen --no-sync coverage report --show-missing
+        uv run --frozen --no-sync coverage xml
 
     - name: Upload coverage reports
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f

--- a/README.md
+++ b/README.md
@@ -2205,6 +2205,20 @@ uv run ruff format simplebroker tests bin examples
 uv run mypy simplebroker bin/release.py
 ```
 
+CI uses one pinned uv release while local development accepts the compatible
+uv 0.11 line. Update both policies and all three lockfiles with one command:
+
+```bash
+python bin/bump_uv.py \
+  --ci-version 0.11.28 \
+  --required-version '>=0.11.11,<0.12'
+python bin/bump_uv.py --check
+```
+
+Run the update with system Python. This still works when a newly installed uv
+falls outside the old repository range. Review the workflow and lockfile diffs
+before running the normal tests.
+
 Property-based tests (`tests/test_property_*.py`, powered by Hypothesis)
 check parser totality/round-trips and run a stateful model of queue
 semantics against every backend; failures print a `@reproduce_failure`

--- a/bin/bump_uv.py
+++ b/bin/bump_uv.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Update and verify the repository-wide uv version policy."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+WORKFLOWS = (
+    "fuzz.yml",
+    "release-gate.yml",
+    "release-gate-pg.yml",
+    "release-gate-redis.yml",
+    "test.yml",
+    "test-pg-extension.yml",
+    "test-redis-extension.yml",
+)
+LOCK_DIRECTORIES = (
+    Path("."),
+    Path("extensions/simplebroker_pg"),
+    Path("extensions/simplebroker_redis"),
+)
+VERSION_RE = re.compile(r"^\d+\.\d+\.\d+$")
+REQUIRED_VERSION_RE = re.compile(
+    r"^>=(?P<minimum>\d+\.\d+\.\d+),<(?P<maximum>\d+\.\d+(?:\.\d+)?)$"
+)
+
+
+class PolicyError(RuntimeError):
+    """Raised when the uv policy is incomplete or inconsistent."""
+
+
+def _version_tuple(value: str) -> tuple[int, ...]:
+    return tuple(int(part) for part in value.split("."))
+
+
+def _validate_versions(ci_version: str, required_version: str) -> None:
+    if not VERSION_RE.fullmatch(ci_version):
+        raise PolicyError(f"invalid CI uv version: {ci_version!r}")
+    match = REQUIRED_VERSION_RE.fullmatch(required_version)
+    if match is None:
+        raise PolicyError("required uv version must look like '>=0.11.28,<0.12'")
+    pinned = _version_tuple(ci_version)
+    minimum = _version_tuple(match.group("minimum"))
+    maximum = _version_tuple(match.group("maximum"))
+    if not minimum <= pinned < maximum:
+        raise PolicyError(
+            f"CI uv {ci_version} is outside required range {required_version}"
+        )
+
+
+def _workflow_paths(root: Path) -> tuple[Path, ...]:
+    directory = root / ".github" / "workflows"
+    paths = tuple(directory / name for name in WORKFLOWS)
+    missing = [path.relative_to(root) for path in paths if not path.is_file()]
+    if missing:
+        raise PolicyError(
+            f"missing managed workflow(s): {', '.join(map(str, missing))}"
+        )
+
+    managed = set(paths)
+    workflow_files = (*directory.glob("*.yml"), *directory.glob("*.yaml"))
+    unmanaged = sorted(
+        path.relative_to(root)
+        for path in workflow_files
+        if "astral-sh/setup-uv@" in path.read_text() and path not in managed
+    )
+    if unmanaged:
+        raise PolicyError(
+            "workflow(s) use setup-uv but are not managed: "
+            + ", ".join(map(str, unmanaged))
+        )
+    return paths
+
+
+def _updated_pyproject(text: str, required_version: str) -> str:
+    section = re.search(r"(?ms)^\[tool\.uv\]\n(?P<body>.*?)(?=^\[|\Z)", text)
+    if section is None:
+        raise PolicyError("pyproject.toml has no [tool.uv] section")
+    body = section.group("body")
+    matches = re.findall(r'(?m)^required-version[ \t]*=[ \t]*"[^"]+"[ \t]*$', body)
+    setting = f'required-version = "{required_version}"'
+    if len(matches) > 1:
+        raise PolicyError("pyproject.toml has more than one uv required-version")
+    if matches:
+        new_body = re.sub(
+            r'(?m)^required-version[ \t]*=[ \t]*"[^"]+"[ \t]*$',
+            setting,
+            body,
+        )
+    else:
+        new_body = f"{setting}\n{body}"
+    return text[: section.start("body")] + new_body + text[section.end("body") :]
+
+
+def _updated_workflow(text: str, ci_version: str, path: Path) -> str:
+    matches = re.findall(r'(?m)^  UV_VERSION:[ \t]*"[^"]+"[ \t]*$', text)
+    setting = f'  UV_VERSION: "{ci_version}"'
+    if len(matches) > 1:
+        raise PolicyError(f"{path.name} has more than one UV_VERSION")
+    if matches:
+        return re.sub(r'(?m)^  UV_VERSION:[ \t]*"[^"]+"[ \t]*$', setting, text)
+    if not re.search(r"(?m)^jobs:[^\n]*(?:\n|$)", text):
+        raise PolicyError(f"{path.name} has no top-level jobs key")
+    return re.sub(
+        r"(?m)^jobs:(?P<suffix>[^\n]*)(?P<newline>\n|$)",
+        rf"env:\n{setting}\n\njobs:\g<suffix>\g<newline>",
+        text,
+        count=1,
+    )
+
+
+def _configured_versions(root: Path, workflows: tuple[Path, ...]) -> tuple[str, str]:
+    pyproject = (root / "pyproject.toml").read_text()
+    match = re.search(
+        r'(?ms)^\[tool\.uv\]\n.*?^required-version[ \t]*=[ \t]*"([^"]+)"[ \t]*$',
+        pyproject,
+    )
+    if match is None:
+        raise PolicyError("pyproject.toml has no uv required-version")
+    required_version = match.group(1)
+
+    pins: dict[Path, str] = {}
+    for path in workflows:
+        matches = re.findall(
+            r'(?m)^  UV_VERSION:[ \t]*"([^"]+)"[ \t]*$', path.read_text()
+        )
+        if len(matches) != 1:
+            raise PolicyError(f"{path.name} must have exactly one UV_VERSION")
+        pins[path] = matches[0]
+    versions = set(pins.values())
+    if len(versions) != 1:
+        details = ", ".join(f"{path.name}={version}" for path, version in pins.items())
+        raise PolicyError(f"workflow uv versions differ: {details}")
+    ci_version = versions.pop()
+    _validate_versions(ci_version, required_version)
+    return ci_version, required_version
+
+
+def _run_lock_commands(root: Path, *, check: bool) -> None:
+    for directory in LOCK_DIRECTORIES:
+        command = ["uv", "lock"]
+        if directory != Path("."):
+            command.extend(["--directory", str(directory)])
+        if check:
+            command.append("--check")
+        subprocess.run(command, cwd=root, check=True)
+
+
+def _restore(originals: dict[Path, bytes | None]) -> None:
+    for path, contents in originals.items():
+        if contents is None:
+            path.unlink(missing_ok=True)
+        else:
+            path.write_bytes(contents)
+
+
+def _update(
+    root: Path, ci_version: str, required_version: str, *, dry_run: bool
+) -> None:
+    _validate_versions(ci_version, required_version)
+    workflows = _workflow_paths(root)
+    pyproject = root / "pyproject.toml"
+    updates = {
+        pyproject: _updated_pyproject(pyproject.read_text(), required_version),
+        **{
+            path: _updated_workflow(path.read_text(), ci_version, path)
+            for path in workflows
+        },
+    }
+    changed = [path for path, text in updates.items() if path.read_text() != text]
+    if dry_run:
+        for path, text in updates.items():
+            status = "would update" if path.read_text() != text else "unchanged"
+            print(f"{path.relative_to(root)}: {status}")
+        return
+    for path in changed:
+        print(path.relative_to(root))
+
+    lock_paths = tuple(
+        root / directory / "uv.lock" if directory != Path(".") else root / "uv.lock"
+        for directory in LOCK_DIRECTORIES
+    )
+    originals = {
+        path: path.read_bytes() if path.exists() else None
+        for path in (*updates, *lock_paths)
+    }
+    try:
+        for path, text in updates.items():
+            path.write_text(text)
+        _run_lock_commands(root, check=False)
+        _configured_versions(root, workflows)
+        _run_lock_commands(root, check=True)
+    except BaseException:
+        _restore(originals)
+        raise
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--ci-version", help="exact uv version used by CI")
+    parser.add_argument("--required-version", help="allowed local uv version range")
+    parser.add_argument("--dry-run", action="store_true", help="report changes only")
+    parser.add_argument("--check", action="store_true", help="verify policy and locks")
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path(__file__).resolve().parents[1],
+        help=argparse.SUPPRESS,
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    root = args.root.resolve()
+    try:
+        workflows = _workflow_paths(root)
+        if args.check:
+            if args.dry_run or args.ci_version or args.required_version:
+                raise PolicyError("--check cannot be combined with update options")
+            ci_version, required_version = _configured_versions(root, workflows)
+            _run_lock_commands(root, check=True)
+            print(f"uv policy is current: CI {ci_version}; local {required_version}")
+        else:
+            if args.ci_version is None or args.required_version is None:
+                raise PolicyError(
+                    "updates require both --ci-version and --required-version"
+                )
+            _update(
+                root,
+                args.ci_version,
+                args.required_version,
+                dry_run=args.dry_run,
+            )
+    except (OSError, PolicyError, subprocess.CalledProcessError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bin/pytest-redis
+++ b/bin/pytest-redis
@@ -91,12 +91,13 @@ def _uv_command(*args: str) -> list[str]:
     return [
         "uv",
         "run",
+        "--project",
+        str(ROOT),
+        "--locked",
         "--extra",
         "dev",
-        "--with-editable",
-        ".",
-        "--with-editable",
-        "./extensions/simplebroker_redis[dev]",
+        "--extra",
+        "redis",
         *args,
     ]
 

--- a/docs/plans/2026-07-12-release-reproducibility-and-publication-hardening-plan.md
+++ b/docs/plans/2026-07-12-release-reproducibility-and-publication-hardening-plan.md
@@ -1,0 +1,1324 @@
+# Release Reproducibility and Publication Hardening Plan
+
+## Purpose
+
+This document is the implementation plan for two linked improvements:
+
+1. make CI and release builds consume checked-in, current dependency locks
+   instead of resolving live environments
+2. make release tags and GitHub Releases write-once while preserving the
+   existing PyPI Trusted Publishing flow
+
+It also includes three small, high-value follow-ups discovered during the same
+review:
+
+- authenticate Codecov uploads with OIDC and fail visibly when upload fails
+- enforce the repository's existing full-SHA Actions convention in GitHub
+  settings
+- run the already-maintained Python examples in normal CI
+
+This plan is intentionally scoped for a solo-maintained public library. It does
+**not** add mandatory pull requests, independent approval, release reviewers,
+or an OpenSSF badge. It hardens machine-verifiable publication boundaries.
+
+Assume the implementer has no prior context. Follow the tasks in order. Do not
+apply the irreversible GitHub settings until the compatible workflow changes
+are merged to `main`.
+
+Revised 2026-07-13 after solo-maintainer burden review: final release tags are
+created only after exact-SHA CI is green, uv version changes use a checked-in
+maintenance command, publication-state logic is shared outside the three
+trusted-publisher workflow files, rollout is split into three reviewable PRs,
+and Codecov failures remain visible without making a reporting-service outage
+block otherwise-green CI. The earlier bounded (not exact) Hatchling decision,
+delete-and-recreate draft idempotency, PyPI lag budget, closed-list
+`--frozen --no-sync` invariant, example-mypy helper flag, and 85% local
+coverage floor remain.
+
+## Verified Current State
+
+Verified on 2026-07-12 (America/Chicago) at `main` SHA `7311c278`.
+
+| Area | Current state | Evidence |
+|---|---|---|
+| PyPI authentication | Correct: all three packages use Trusted Publishing with `id-token: write`; no long-lived PyPI token is passed | `.github/workflows/release-gate*.yml` |
+| Artifact provenance | Correct: all three release workflows generate Sigstore attestations and attach the bundle to the GitHub Release | `.github/workflows/release-gate*.yml` |
+| Action pinning in YAML | Correct: all 15 `uses:` references are pinned to 40-character SHAs | `.github/workflows/*.yml` |
+| Repository Actions policy | Permits all actions; full-SHA pinning is not enforced by GitHub | `GET /repos/VanL/simplebroker/actions/permissions` returns `allowed_actions: all`, `sha_pinning_required: false` |
+| Root lock | Current | `uv lock --check` exits 0 |
+| Postgres extension lock | Stale | `uv lock --check --directory extensions/simplebroker_pg` exits 1 |
+| Redis extension lock | Stale | `uv lock --check --directory extensions/simplebroker_redis` exits 1 |
+| Normal test install | Resolves live via `uv pip install --system -e ".[dev]"` | `.github/workflows/test.yml` |
+| Extension test helpers | Add editable packages with `uv run --with-editable`, which creates a live overlay instead of proving the root lock | `simplebroker/_scripts.py`, `bin/pytest-redis` |
+| Release build frontend | `uv build` resolves the unpinned `hatchling` build requirement in an isolated environment | `pyproject.toml`, both extension `pyproject.toml` files, release workflows |
+| Release cache | Enabled in all three release build jobs | `.github/workflows/release-gate*.yml` |
+| Release tag movement | The local release helper supports `--retag`, including deleting and recreating remote tags | `bin/release.py` |
+| Recent tag correction frequency | 9 of 34 release tag names in the available 2026-06-11 through 2026-07-11 workflow history ran against more than one SHA, grouped into five correction events; several followed Windows-only CI failures | GitHub Actions runs for the three `release-gate*.yml` workflows |
+| Release tag rules | No tag ruleset exists | `GET /repos/VanL/simplebroker/rulesets` returns only the default-branch destructive-update ruleset |
+| GitHub Release immutability | Disabled; current releases report `immutable: false` | `GET /repos/VanL/simplebroker/immutable-releases` returns `enabled: false` |
+| PyPI environment policy | Environment exists, but any branch or tag may target it; administrators may bypass | `GET /repos/VanL/simplebroker/environments/pypi` |
+| Codecov | Coverage is calculated locally, but an upload failed with `Token required because branch is protected`; `fail_ci_if_error: false` kept the job green | `.github/workflows/test.yml` and Actions run `29214380088` |
+| Example verification | 80 Python example tests, mypy, and ShellCheck pass locally; Python example checks are run by the release helper but not normal CI | `examples/`, `bin/release.py` |
+
+## What Already Works (Do Not Replace)
+
+Preserve these controls:
+
+- PyPI Trusted Publishing through the `pypi` environment
+- the three existing top-level release workflow filenames:
+  - `.github/workflows/release-gate.yml`
+  - `.github/workflows/release-gate-pg.yml`
+  - `.github/workflows/release-gate-redis.yml`
+- the PyPI trusted-publisher identities bound to those workflow files
+- top-level workflow gates that require the relevant test workflows to pass on
+  the exact release commit
+- package-version-to-tag validation
+- checkout by `${{ github.sha }}`
+- least-privilege job permissions
+- Sigstore artifact attestations
+- separate root, Postgres, and Redis distributions
+- existing Dependabot cooldowns and fail-closed auto-merge gate
+- current default-branch rules: block deletion and non-fast-forward updates,
+  without adding PR-only or approval requirements
+- all timing-sensitive and contention-heavy tests exactly as tests; do not
+  serialize them or relax their thresholds in this work
+
+Do **not** consolidate publication into a reusable workflow. PyPI Trusted
+Publishing identifies the calling workflow file. A cleanup that changes that
+identity can break publication or require new trusted-publisher entries.
+
+This restriction applies to the top-level workflow identity, not to checked-in
+implementation helpers. Keep the three workflow filenames and publication
+jobs, but put GitHub Release discovery, draft replacement, exact-SHA checks,
+PyPI lag polling, and final publication state handling in one shared Python
+script. Do not maintain three copies of the same API state machine in YAML.
+
+## Locked Decisions
+
+### Trusted Publishing stays
+
+- Do not add `PYPI_TOKEN`, `TWINE_PASSWORD`, API tokens, or repository secrets.
+- Keep `pypa/gh-action-pypi-publish` and job-scoped `id-token: write`.
+- Keep the environment name exactly `pypi` for all three packages.
+
+### Remote release tags become write-once
+
+Once a release tag reaches `origin`, it may not move or be deleted.
+
+- Remove the `--retag` CLI option.
+- Remove the `replace_remote` tag action and remote-tag deletion path.
+- A remote tag at the wrong commit is a hard error.
+- Do not use the final release tag as a candidate marker. The release helper
+  must push the release commit to `main`, wait for the target's required
+  workflows to pass on that exact SHA, and only then create and push the tag.
+- A CI failure before the remote tag exists does **not** burn the version. Fix
+  the commit and rerun the helper with the same unpublished version.
+- After a remote tag exists, a transient publication failure may be rerun only
+  against that same tag and SHA. If recovery requires a code change, the tag
+  and version are consumed; publish the fix as a new patch version.
+- The pre-tag wait is resumable. If the helper is interrupted after pushing
+  `main` but before pushing the tag, rerunning it at the same unpublished
+  version reuses the existing commit, observes or resumes exact-SHA CI, and
+  creates the tag only after success.
+- Local-only tags may still be replaced before they are pushed.
+
+This is deliberately stricter than the branch policy. Release tags are public
+supply-chain identifiers, not collaboration branches. Delaying the tag until
+cross-platform CI is green puts the irreversible boundary after reversible
+validation instead of making routine CI discovery consume public versions.
+
+### Immutable Releases apply only after workflow compatibility
+
+GitHub recommends attaching all assets to a draft before publishing an
+immutable release. Therefore:
+
+1. merge the draft-first workflow changes
+2. apply tag and environment policies
+3. enable immutable releases last
+
+Do not enable release immutability against the current upload-after-publish
+workflow shape.
+
+### One root lock drives repository CI
+
+- `uv.lock` at the repository root is the execution lock for normal tests,
+  lint, coverage, examples, backend test helpers, packaging smoke, and release
+  builds.
+- Extension lockfiles remain supported for developers working directly inside
+  an extension and for Dependabot.
+- All three lockfiles must pass `uv lock --check` in CI.
+- A lockfile that is kept but never checked is not an acceptable artifact.
+
+### CI uses a fixed uv version
+
+- Pin GitHub Actions to uv `0.11.28`, routed through a per-workflow
+  `env: UV_VERSION` value (as `release-gate.yml` already does) so a version
+  bump is one line per workflow file.
+- Every `astral-sh/setup-uv` step must reference `${{ env.UV_VERSION }}`; no
+  step may carry its own literal version.
+- Add `required-version = ">=0.11.11,<0.12"` under `[tool.uv]` so local
+  development remains compatible across the supported uv minor line. The
+  ceiling is deliberate: a too-new local uv fails with an explicit refusal
+  instead of regenerating locks that the pinned CI resolver may reject.
+- Add a workflow-structure test that every uv-installing workflow defines the
+  same `UV_VERSION` value and that every setup-uv step references it.
+- Add a stdlib-only `bin/bump_uv.py` maintenance command. It accepts the exact CI
+  version and the supported local range, updates `[tool.uv].required-version`
+  plus every workflow `UV_VERSION`, and regenerates all three lockfiles. It
+  supports `--check` and `--dry-run`; check mode validates the range/pin
+  invariant and runs all three lock freshness checks. The command validates
+  that every expected workflow was updated exactly once and fails rather than
+  partially updating an unknown workflow shape.
+- Updating the pinned CI uv version is a normal dependency-maintenance change,
+  with all lock and packaging gates required. Dependabot updates the setup-uv
+  action SHA but never `version:` inputs or `required-version`. The expected
+  trigger is local breakage after a Homebrew uv upgrade past the ceiling. Run
+  the maintenance command with system Python (not `uv run`, because the old
+  range may reject the installed uv), review its workflow and lock diffs, then
+  run the normal gates. Document the exact command in the README release
+  section.
+
+### Release builds use a locked, non-isolated frontend
+
+Add an opt-in `release` dependency group containing exact versions:
+
+```toml
+[dependency-groups]
+release = [
+    "build==1.5.1",
+    "hatchling==1.31.0",
+]
+```
+
+The exact versions must be present in `uv.lock`. Release and packaging jobs must
+invoke `python -m build --no-isolation` from the root locked environment. Do not
+let PEP 517 create a second environment and resolve a newer backend.
+
+Bound the three `[build-system].requires` entries to `hatchling>=1.31,<2`. Do
+**not** pin an exact backend version in published metadata: repository builds
+already get the exact version from the lock plus `--no-isolation`, while an
+exact pin in a published sdist constrains every downstream rebuilder (distro
+packagers, future `pip install` from sdist) forever and turns each Hatchling
+bump into a mandatory release of all three packages.
+
+### Release jobs do not consume Actions caches
+
+- Set `enable-cache: false` explicitly on the setup-uv step in all three
+  release workflows.
+- Do not add `actions/cache` to a release workflow.
+- Normal test and fuzz workflows may continue using caches.
+
+### Codecov uses OIDC
+
+- Give only the coverage job `id-token: write` plus `contents: read`.
+- Set `use_oidc: true`.
+- Remove the unused `CODECOV_TOKEN` input.
+- Set `fail_ci_if_error: true` on the Codecov action so the upload step records
+  an accurate failure, but set `continue-on-error: true` on that step and emit
+  an explicit workflow warning when `steps.codecov.outcome == 'failure'`.
+  Codecov is external reporting, not the coverage gate; an outage must be
+  visible without blocking a green local coverage result or Dependabot merge.
+- Add `fail_under = 85` to the local coverage report configuration so the
+  coverage gate remains meaningful even if Codecov is unavailable. Measured
+  combined coverage on 2026-07-12 is 92.4%; the floor is set to catch collapse
+  (an untested module landing, broken coverage wiring), not to fight refactors
+  that delete well-covered code.
+
+### Solo-maintainer operational budget
+
+- A normal release remains one helper invocation plus unattended CI wait. It
+  must not require manual tag creation, settings inspection, asset upload, or
+  version recovery on the green path.
+- Interrupting the helper during its pre-tag wait is safe and resumable.
+- A uv compatibility bump is one checked-in command plus diff review and normal
+  gates, not a hand-edited multi-file runbook.
+- The completion-evidence table and first immutable release record are rollout
+  artifacts, not a checklist to repeat for every later release.
+- Codecov availability never overrides the local coverage gate.
+- New services, bots, reviewers, or approval queues remain out of scope.
+
+## Non-Goals
+
+- no runtime queue, watcher, backend, retry, or timing behavior changes
+- no test serialization or wider timing budgets
+- no PR approval requirement
+- no release reviewer requirement
+- no change from Trusted Publishing to token-based publishing
+- no uv workspace conversion
+- no consolidation of the three release workflows
+- no new release orchestration service or GitHub App
+- no SBOM project in this slice
+- no attempt to make old GitHub Releases retroactively immutable
+- no claim of bit-for-bit reproducibility across arbitrary operating systems;
+  the target is a fixed resolver, fixed build frontend, fixed source SHA, and
+  cache-independent hosted build
+
+## Repository Primer and File Map
+
+| File or setting | Role | Planned change |
+|---|---|---|
+| `pyproject.toml` | Root dependencies, uv, build backend, coverage | Add release group, uv version range, bounded Hatchling requirement, and 85% local coverage floor |
+| `uv.lock` | Root execution lock | Add exact release tools and refresh metadata |
+| `extensions/simplebroker_pg/pyproject.toml` | PG build metadata | Bound Hatchling build requirement to `>=1.31,<2` |
+| `extensions/simplebroker_pg/uv.lock` | PG-local lock | Regenerate and prove current |
+| `extensions/simplebroker_redis/pyproject.toml` | Redis build metadata | Bound Hatchling build requirement to `>=1.31,<2` |
+| `extensions/simplebroker_redis/uv.lock` | Redis-local lock | Regenerate and prove current |
+| `.github/workflows/test.yml` | Main matrix, lint, packaging, coverage | Frozen sync/run, lock job, examples, Codecov OIDC |
+| `.github/workflows/test-pg-extension.yml` | PG service and extension gates | Frozen root environment and explicit uv version |
+| `.github/workflows/test-redis-extension.yml` | Redis service and extension gates | Frozen root environment and explicit uv version |
+| `.github/workflows/release-gate.yml` | Core publication | Cache-free locked build and draft-first immutable release flow |
+| `.github/workflows/release-gate-pg.yml` | PG publication | Same release mechanics for PG tag pattern |
+| `.github/workflows/release-gate-redis.yml` | Redis publication | Same release mechanics for Redis tag pattern |
+| other `.github/workflows/*.yml` | CodeQL, Scorecard, fuzz, Dependabot | Explicit uv version where applicable; otherwise preserve behavior |
+| `bin/bump_uv.py` | uv maintenance automation | Update the local uv range and every workflow pin atomically, regenerate all three locks, and support check/dry-run modes |
+| `simplebroker/_scripts.py` | PG test and packaging developer helpers | Replace live editable/build overlays with locked root-project invocations; no broker runtime semantics change |
+| `bin/pytest-redis` | Redis service-test helper | Replace live editable overlay with locked root-project invocation |
+| `bin/release.py` | Maintainer preflight, release commit, CI wait, tag creation, release checks | Remove remote retagging, require exact-SHA CI on `main` before the tag push, add fail-closed repository-settings verification, and expose `--check-example-types` |
+| `.github/scripts/require_green_workflows.py` | Existing exact-SHA workflow poller | Reuse from the local release helper before tag creation; preserve the post-tag workflow check as defense in depth |
+| `.github/scripts/release_publication.py` | Shared GitHub Release state machine | Discover/delete matching drafts, verify expected tag/SHA/assets, publish drafts, and handle exact already-published reruns plus PyPI lag |
+| `tests/test_release_workflow.py` | Workflow structure regressions | Add lock, build, draft, OIDC, and pin-policy assertions |
+| `tests/test_release_script.py` | Release helper regressions | Add immutable-tag and repository-setting tests |
+| `tests/test_release_publication_script.py` | Shared publication-state regressions | Cover draft replacement, mismatched state, publication, and exact rerun behavior without duplicating API logic in YAML |
+| `tests/test_bump_uv.py` | uv maintenance regressions | Cover atomic updates, check/dry-run behavior, unknown workflow shapes, and command failures |
+| `tests/test_dev_scripts.py` | Developer helper regressions | Assert PG helper uses the root lock without ephemeral editable overlays |
+| `tests/test_redis_dev_script.py` or existing Redis helper tests | Redis helper regressions | Assert Redis helper uses the root lock without ephemeral editable overlays |
+| `README.md` | Current release instructions | Document write-once tags, immutable releases, frozen build contract, and recovery behavior |
+| GitHub Actions permissions | Repository setting | Selected actions plus full-SHA enforcement |
+| `pypi` environment | Repository setting | Allow only the three release-tag families |
+| release-tag ruleset | Repository setting | Block tag updates/deletions without blocking creation |
+| immutable releases | Repository setting | Enable only after draft-first jobs are merged |
+
+## External References
+
+- GitHub immutable releases and draft-first guidance:
+  <https://docs.github.com/en/code-security/concepts/supply-chain-security/immutable-releases>
+- Enable repository release immutability:
+  <https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/establish-provenance-and-integrity/prevent-release-changes>
+- GitHub tag rulesets:
+  <https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/creating-rulesets-for-a-repository>
+- Environment branch and tag policies:
+  <https://docs.github.com/en/actions/reference/workflows-and-actions/deployments-and-environments>
+- Repository Actions permissions and SHA enforcement:
+  <https://docs.github.com/en/rest/actions/permissions>
+- uv lock checking and frozen sync:
+  <https://docs.astral.sh/uv/concepts/projects/sync/>
+- Codecov OIDC:
+  <https://github.com/codecov/codecov-action#using-oidc>
+
+## Engineering Rules
+
+### Red-green TDD
+
+For each repository task:
+
+1. add or strengthen the structural/unit test first
+2. prove it fails for the intended reason
+3. make the smallest production or workflow change
+4. rerun the focused test
+5. rerun the relevant local gate before moving on
+
+GitHub settings cannot be made red locally. For those tasks, the red evidence is
+the captured API baseline. The green evidence is an authenticated API readback
+after the setting changes.
+
+### No text-only workflow tests
+
+Workflow structure tests may parse YAML/text for invariants, but every command
+shape must also be exercised by at least one real local invocation:
+
+- all three lock checks
+- root frozen sync
+- PG and Redis locked helper invocation
+- packaging smoke using the locked, non-isolated build frontend
+- `python bin/bump_uv.py --check` and `--dry-run`
+- `bin/release.py --dry-run`
+
+Do not claim reproducibility solely because a YAML line contains `--frozen`.
+
+### Fail closed at mutation boundaries
+
+The release helper must verify GitHub release settings before it creates a
+release commit or pushes a tag. After pushing the release commit to `main`, it
+must require the target's normal workflows to pass on that exact SHA before it
+creates the local tag or pushes any tag. `--skip-checks` may skip expensive
+local tests; it must not skip repository-setting verification, exact-SHA CI,
+publication-state checks, tag-state checks, branch checks, or version checks.
+
+### Preserve local developer ergonomics
+
+`bin/pytest-pg` and `bin/pytest-redis` should continue to provision their
+containers automatically. Their nested Python test command should use the root
+project lock, but callers should not need to pre-create a virtual environment.
+
+Use `uv run --locked` for these local bootstrap helpers. In already-synced CI
+steps, use `uv run --frozen --no-sync` where no nested helper needs to change the
+environment.
+
+## Dependency and Execution Order
+
+```text
+Task 0: baseline
+  |
+  v
+Task 1: current locks + fixed uv + frozen CI
+  |
+  v
+Task 2: locked build frontend + cache-free release builds
+  |
+  v
+PR A: merge Tasks 1-2 and prove reproducibility CI
+  |
+  v
+Task 3: pre-tag CI gate + write-once tag helper + shared draft-first flow
+  |
+  v
+PR B: merge Task 3 and prove publication-flow structure
+  |
+  v
+Task 4: quick wins
+  |
+  v
+PR C: merge Task 4 and prove independent CI changes
+  |
+  v
+Task 5: verify all three merged slices together on main
+  |
+  v
+Task 6: apply GitHub settings
+  |
+  v
+Task 7: readback + next-release proof
+```
+
+Why this order:
+
+- frozen CI cannot work until locks are current
+- non-isolated builds cannot work until the release frontend is in the lock
+- a final tag must not exist until the release commit is on `main` and its
+  target-specific required workflows are green on that exact SHA
+- immutable releases should not be enabled until assets are staged on a draft
+- tag-update restrictions should not be enabled while the helper still offers
+  `--retag`
+- GitHub settings must be applied only after the matching code is on `main`
+- three smaller PRs isolate resolver/build changes, the publication state
+  machine, and unrelated CI quick wins so one failure has a narrow cause
+
+## Task 0: Capture the Baseline
+
+### Goal
+
+Record enough state to distinguish an intentional setting change from drift.
+
+### Steps
+
+1. Record the starting SHA and clean worktree:
+
+   ```bash
+   git rev-parse HEAD
+   git status --short --branch
+   ```
+
+2. Record all lock results:
+
+   ```bash
+   uv lock --check
+   uv lock --check --directory extensions/simplebroker_pg
+   uv lock --check --directory extensions/simplebroker_redis
+   ```
+
+   Expected baseline: root passes; PG and Redis fail.
+
+3. Record the unique Actions inventory and verify every reference is currently
+   a full SHA.
+
+4. Save authenticated JSON readbacks for:
+
+   ```bash
+   gh api -H 'X-GitHub-Api-Version: 2026-03-10' \
+     /repos/VanL/simplebroker/immutable-releases
+   gh api -H 'X-GitHub-Api-Version: 2026-03-10' \
+     /repos/VanL/simplebroker/actions/permissions
+   gh api -H 'X-GitHub-Api-Version: 2026-03-10' \
+     /repos/VanL/simplebroker/environments/pypi
+   gh api /repos/VanL/simplebroker/rulesets
+   ```
+
+5. Record the last successful core, PG, Redis, packaging, CodeQL, Scorecard,
+   and fuzz run URLs.
+
+### Gate
+
+PR A contains the starting SHA, three lock outcomes, current action inventory,
+current settings JSON summary, and current green run URLs. PRs B and C link
+back to that baseline instead of copying it; refresh only evidence that changed
+between slices.
+
+## Task 1: Make Locks Authoritative in CI
+
+### Primary files
+
+- `pyproject.toml`
+- `uv.lock`
+- `extensions/simplebroker_pg/uv.lock`
+- `extensions/simplebroker_redis/uv.lock`
+- `.github/workflows/test.yml`
+- `.github/workflows/test-pg-extension.yml`
+- `.github/workflows/test-redis-extension.yml`
+- other workflows containing `astral-sh/setup-uv`
+- `bin/bump_uv.py`
+- `simplebroker/_scripts.py`
+- `bin/pytest-redis`
+- focused tests listed in the file map
+
+### Red tests first
+
+Add tests that require:
+
+1. every uv-installing workflow to define an exact `env: UV_VERSION`, every
+   setup-uv step to reference `${{ env.UV_VERSION }}`, all workflows to agree
+   on one value, and the initial implementation to set that value to `0.11.28`
+2. the main `Test` workflow to run all three `uv lock --check` commands
+3. no normal test, lint, coverage, PG, or Redis workflow to contain
+   `uv pip install`, `pip install`, or a live `--with-editable` overlay
+4. each job to sync the exact extras it needs with `uv sync --frozen`
+5. in `test.yml`, `test-pg-extension.yml`, and `test-redis-extension.yml`,
+   every post-sync step that invokes a Python-ecosystem tool to go through
+   `uv run --frozen --no-sync`; any exception must be enumerated inside the
+   test itself (expected: none)
+6. PG helper commands to use the root lock plus `--extra pg`
+7. Redis helper commands to use the root lock plus `--extra redis`
+8. both helpers to reject a stale root lock instead of rewriting it
+9. `bin/bump_uv.py --check` to prove the root range and every workflow pin agree
+10. `bin/bump_uv.py --dry-run` to report every intended file without changing it,
+    and mutation tests to prove unknown/missing/duplicate workflow pins fail
+    before any file is written
+
+### Implementation
+
+1. Add the stdlib-only `bin/bump_uv.py` command described in Locked Decisions.
+   Its write path must stage all text changes in memory, validate the complete
+   file set, save original bytes, apply the edits, then regenerate all three
+   locks. On a caught write or lock-generation failure, restore every original
+   file and exit nonzero. Successful changes remain in the worktree for normal
+   diff review.
+2. Use it for the initial version/range update:
+
+   ```bash
+   python bin/bump_uv.py \
+     --ci-version 0.11.28 \
+     --required-version '>=0.11.11,<0.12'
+   ```
+
+   The command updates `[tool.uv].required-version`, sets the same
+   `UV_VERSION` in every uv-installing workflow, and runs the three `uv lock`
+   commands. Review all generated lock changes.
+3. Add a small `locks` job to `Test` that runs
+   `python bin/bump_uv.py --check`; the command performs all three lock checks
+   as well as the range/pin consistency check.
+4. Replace the main test/lint/coverage system installs with explicit syncs:
+
+   - core matrix: `uv sync --frozen --extra dev`
+   - root lint/type check: `uv sync --frozen --extra dev --extra pg --extra redis`
+   - coverage: `uv sync --frozen --extra dev --extra pg --extra redis`
+   - PG workflow: `uv sync --frozen --extra dev --extra pg`
+   - Redis workflow: `uv sync --frozen --extra dev --extra redis`
+
+5. Run post-sync tools with `uv run --frozen --no-sync`.
+6. Change CLI installation checks to:
+
+   ```bash
+   uv run --frozen --no-sync broker --version
+   uv run --frozen --no-sync simplebroker --version
+   ```
+
+7. Replace PG/Redis helper `--with-editable` overlays with locked root-project
+   extras. Preserve automatic container management and the existing test
+   selection behavior.
+8. Set the shared `UV_VERSION` env and setup-uv reference on CodeQL-adjacent,
+   fuzz, test, and release workflows that install uv.
+9. Document the stdlib command in README. Do not tell maintainers to perform
+   seven workflow edits and three lock regenerations by hand.
+
+### Gates
+
+```bash
+python bin/bump_uv.py --check
+uv run pytest -q -n0 \
+  tests/test_bump_uv.py \
+  tests/test_release_workflow.py \
+  tests/test_dev_scripts.py \
+  tests/test_release_script.py
+uv run ./bin/pytest-pg --fast
+uv run ./bin/pytest-redis --fast
+```
+
+All commands pass, and rerunning them leaves every lockfile byte-for-byte
+unchanged.
+
+## Task 2: Lock the Build Frontend and Remove Release Caches
+
+### Primary files
+
+- all three `pyproject.toml` files
+- `uv.lock`
+- `simplebroker/_scripts.py`
+- all three release workflows
+- packaging/release tests
+
+### Red tests first
+
+Add tests that fail until:
+
+- the root release group contains exact `build` and `hatchling` versions
+- every build-system requirement declares `hatchling>=1.31,<2` and none pins
+  an exact backend version
+- release workflows contain no bare `uv build`
+- release workflows build with `python -m build --no-isolation`
+- release setup-uv steps explicitly disable cache
+- packaging smoke uses the root locked release group for all three projects
+
+### Implementation
+
+1. Add the locked release group from the Locked Decisions section.
+2. Bound Hatchling to `>=1.31,<2` in the root, PG, and Redis build-system
+   tables.
+3. Refresh `uv.lock` and prove Hatchling is present with hashes.
+4. Change packaging smoke's build helper to invoke the root project explicitly:
+
+   ```text
+   uv run --project <repo-root> --locked --group release \
+     python -m build --no-isolation <project-dir>
+   ```
+
+   Use argument lists, not a shell string. Preserve Windows support.
+
+5. In each release workflow:
+
+   - explicitly disable setup-uv caching
+   - sync the root `release` group from `uv.lock`
+   - build the selected package directory with the locked frontend and
+     `--no-isolation`
+   - keep checkout pinned to `${{ github.sha }}`
+
+6. Do not remove the existing packaging metadata, artifact-install,
+   entry-point, license, or excluded-file checks.
+
+### Gates
+
+```bash
+uv lock --check
+uv run ./bin/packaging-smoke --python 3.11
+uv run pytest -q -n0 \
+  tests/test_release_workflow.py \
+  tests/test_release_script.py \
+  tests/test_dev_scripts.py
+```
+
+Capture the exact `build` and `hatchling` versions printed by packaging smoke.
+No release workflow restores or saves an Actions cache.
+
+### PR A gate
+
+Open PR A with Tasks 1 and 2 only. Require Test, Test Postgres Extension, Test
+Redis Extension, and CodeQL on the PR head; manually run both fuzz jobs because
+resolver and build behavior changed. Merge PR A and require the same normal
+workflows to pass on `main` before starting Task 3. A failure here is a
+resolver/build problem, not mixed publication-state or Codecov work.
+
+## Task 3: Validate Before Tagging and Publish Draft-First
+
+### Primary files
+
+- `bin/release.py`
+- `tests/test_release_script.py`
+- `.github/scripts/require_green_workflows.py`
+- `.github/scripts/release_publication.py`
+- `tests/test_release_publication_script.py`
+- `.github/workflows/release-gate.yml`
+- `.github/workflows/release-gate-pg.yml`
+- `.github/workflows/release-gate-redis.yml`
+- `tests/test_release_workflow.py`
+- `README.md`
+
+### Red tests first
+
+#### Release helper
+
+Add tests proving:
+
+- `--retag` is no longer accepted
+- a wrong remote tag always raises an error that says to choose a new version
+- no command path emits `git push --delete origin <tag>`
+- local-only wrong tags may still be replaced before push
+- a real release must run from `main`; after the release commit is pushed, the
+  stored release SHA must remain reachable from a freshly fetched
+  `origin/main`
+- the helper invokes the existing exact-SHA workflow poller with the correct
+  target-specific workflows before it creates a local tag or pushes a remote
+  tag: core requires Test + PG + Redis, PG requires Test + PG, Redis requires
+  Test + Redis, and a batch uses the union
+- command-order tests prove `git push origin main` happens before the CI wait
+  and all tag creation/push commands happen only after the wait succeeds
+- failed, cancelled, missing, or timed-out pre-tag CI leaves no new local or
+  remote tag and allows the same unpublished version to be retried after a fix
+- an interrupted helper rerun at the same release commit resumes the pre-tag
+  check without creating another release commit or requiring a version bump
+- a normal fast-forward on `main` during the CI wait does not invalidate an
+  already-green stored release SHA; the final tag still names that explicit
+  SHA, while removal of the SHA from `main` fails closed
+- repository-settings verification cannot be bypassed with `--skip-checks`
+- branch, exact-SHA CI, publication-state, tag-state, and version checks cannot
+  be bypassed with `--skip-checks`
+- missing immutable-release, tag-ruleset, environment-policy, or SHA-pinning
+  state fails with one targeted message per missing control
+
+#### Shared publication-state script
+
+Add unit tests proving `.github/scripts/release_publication.py`:
+
+- lists releases to find drafts by `tag_name` instead of assuming the normal
+  tag lookup endpoint can discover drafts
+- deletes only a matching draft and never deletes a published release
+- resolves the remote tag ref independently of the GitHub Release object's
+  `target_commitish` field and rejects any SHA other than the expected release
+  SHA
+- verifies the complete expected wheel, sdist, and Sigstore asset set before
+  final publication
+- publishes the matching draft and fails closed on missing or duplicate state
+- treats an already-published immutable release as rerun success only when the
+  tag, SHA, package version, and PyPI state all match exactly
+- keeps PyPI lag polling bounded to about five attempts over a few minutes and
+  reports the last observed state on failure
+
+#### Workflow structure
+
+For each release workflow, require this order:
+
+```text
+require-tests
+  -> verify-tag-current
+  -> build + attest
+  -> stage-github-release (draft + all assets)
+  -> publish-to-pypi (Trusted Publishing)
+  -> publish-github-release (draft -> published)
+```
+
+Tests must also prove:
+
+- every release workflow uses the shared publication-state script for draft
+  discovery/deletion and final publication; no workflow carries a copied
+  `gh api`, release-list parser, PyPI polling loop, or `gh release edit` state
+  machine
+- all wheel, sdist, and Sigstore files are attached before final publication
+- no file upload occurs after the release leaves draft state
+- the draft-staging job invokes the shared script to delete any pre-existing
+  draft for the tag before staging, so reruns replace drafts instead of
+  duplicating them
+- the PyPI job still uses only `id-token: write`
+- no PyPI secret appears anywhere
+- a failed PyPI job leaves a draft release instead of a partially populated
+  published release
+- final publication depends on successful PyPI publication
+
+### Implementation
+
+1. Remove remote retagging from the release helper and its type definitions.
+2. Add authenticated GitHub settings readback to the release helper. Use the
+   `2026-03-10` API version and never print the token.
+3. Add a standalone read-only command for maintainers:
+
+   ```bash
+   uv run python bin/release.py --check-repository-settings
+   ```
+
+4. Run the same settings check automatically before any non-dry-run release
+   mutates version files, creates a release commit, pushes `main`, or pushes a
+   tag. During the short interval after PR B merges and before Task 6 applies
+   the settings, this intentionally blocks real releases.
+5. Move the final-tag commit point behind exact-SHA CI:
+
+   1. require the current branch to be `main`
+   2. run the existing local prechecks unless `--skip-checks` was passed
+   3. update version files and create the release commit as today
+   4. store the release SHA and push it explicitly with `git push origin main`
+   5. invoke `.github/scripts/require_green_workflows.py` with the authenticated
+      GitHub token, repository slug, stored SHA, and the target-specific normal
+      workflow names
+   6. after the poller succeeds, fetch `origin/main`, require
+      `git merge-base --is-ancestor <release-sha> origin/main`, and re-read
+      remote tag state; a normal later fast-forward does not force a retry
+   7. only then create the local final tag with the stored SHA as an explicit
+      target and push that tag
+
+   Reuse the existing poller rather than building a second GitHub Actions
+   polling implementation. Resolve the token through the release helper's
+   existing environment/`gh auth` path and pass it to the subprocess only as
+   `GITHUB_TOKEN`, never as an argument or printed value. Preserve the release
+   workflow's post-tag
+   `require-tests` job as defense in depth against manual tag creation and
+   state changes between the local wait and hosted build.
+6. Add `.github/scripts/release_publication.py` as the single implementation of
+   GitHub Release discovery, matching-draft deletion, expected-state
+   verification, bounded PyPI polling, and final draft publication. Keep it
+   stdlib-only so workflows do not need a mutable install step. Give it two
+   explicit workflow-facing subcommands:
+
+   - `replace-draft`: accepts repository, tag, and expected-SHA arguments;
+     resolves the remote tag ref, rejects mismatched or published state, and
+     deletes only a matching draft
+   - `publish-draft`: accepts repository, tag, expected SHA, package, version,
+     and repeated expected-asset arguments; verifies the exact draft and asset
+     set, publishes it, and implements the bounded already-published/PyPI
+     rerun check
+
+   Read authentication from `GITHUB_TOKEN`; never accept a token argument or
+   print request headers.
+7. Split the current GitHub Release job into:
+
+   - a draft-staging job that downloads both artifact sets and invokes the
+     shared script to remove a stale matching draft, then invokes the existing
+     pinned `softprops/action-gh-release` with `draft: true`
+   - a final job after PyPI publication that invokes the shared script to
+     verify the release, asset set, tag, and SHA before publishing the draft
+
+8. Make reruns idempotent by replacement, not in-place update:
+
+   - before invoking the release action, the shared script deletes any
+     existing draft release whose `tag_name` matches, then creates a fresh
+     draft with all assets. Do not rely on the release action finding and
+     updating an existing draft; drafts are not reliably discoverable by tag
+     lookup. Draft deletion is unaffected by immutable releases (which bind at
+     publish time) and by the tag ruleset (which governs git refs only)
+   - artifact names remain stable
+   - on the rerun path only, the shared script treats an already-published
+     immutable release at the exact expected tag/SHA as success once PyPI
+     reports that version; it polls the PyPI JSON API with backoff (about five
+     attempts over a few minutes) before declaring failure, because fresh
+     uploads can lag. A first run needs no PyPI query; success is implied by
+     the job dependency on the publish job
+   - any mismatched tag/SHA is a hard failure
+
+9. Update release documentation:
+
+   - remote tags are permanent
+   - a failed pre-tag CI run leaves the version reusable; fix `main` and rerun
+     the helper
+   - retry a transient publication failure when the tag and SHA are correct
+   - if a post-tag recovery needs a new commit, bump to the next patch version
+   - do not delete or reuse a published version
+   - the uv version-bump runbook from the Locked Decisions section
+
+### Gates
+
+```bash
+uv run pytest -q -n0 \
+  tests/test_release_script.py \
+  tests/test_release_publication_script.py \
+  tests/test_release_workflow.py
+uv run python bin/release.py --dry-run
+```
+
+The dry run proposes no remote tag deletion or external mutation and shows this
+order without waiting for live CI: repository settings -> local checks ->
+release commit -> push `main` -> wait for exact-SHA CI -> create/push final tag
+-> hosted draft -> PyPI -> publish immutable release. Existing read-only remote
+publication-state lookups may still run.
+
+### PR B gate
+
+Open PR B with Task 3 only. Require normal PR CI and the focused tests above.
+Merge it after PR A is green on `main`. Before Task 6 applies the repository
+settings, verify the merged helper's dry-run order and the three workflow job
+graphs; do not create a real release tag merely to test this slice.
+
+## Task 4: Apply the Quick Wins
+
+### 4.1 Codecov OIDC and local coverage floor
+
+Files:
+
+- `.github/workflows/test.yml`
+- `pyproject.toml`
+- `tests/test_release_workflow.py`
+
+Tests first:
+
+- coverage job has job-scoped `contents: read` and `id-token: write`
+- Codecov uses `use_oidc: true`
+- `CODECOV_TOKEN` is absent
+- the Codecov step has an `id`, uses `fail_ci_if_error: true`, and is marked
+  `continue-on-error: true`
+- a following step runs only when the Codecov step's `outcome` is `failure`
+  and emits an explicit GitHub workflow warning
+- coverage configuration contains `fail_under = 85`
+
+Gate:
+
+```bash
+uv run pytest -q -n0 tests/test_release_workflow.py \
+  -k 'codecov or coverage'
+```
+
+This focused gate proves the workflow and configuration shape without assuming
+that a `.coverage` data file already exists. Task 5 must run the real coverage
+job, including `coverage report --show-missing`, to prove the current combined
+coverage remains at least 85% (measured 92.4% on 2026-07-12). The initial OIDC
+rollout is not complete until one PR or `main` upload succeeds, but an external
+Codecov outage does not make otherwise-green code unmergeable.
+
+### 4.2 Python examples in normal CI
+
+Add a `--check-example-types` flag to `bin/release.py` that runs the existing
+`_examples_mypy_command()` file-list logic. The root mypy config excludes
+`examples/` from directory discovery, and that helper is already the single
+source of truth for example file discovery; do not duplicate the glob in a
+workflow. Cover the flag in `tests/test_release_script.py`.
+
+Then add these to the existing lint/quality job after its frozen sync:
+
+```bash
+uv run --frozen --no-sync pytest -n0 examples
+uv run --frozen --no-sync python bin/release.py --check-example-types
+```
+
+Do not add a live package installation. Keep ShellCheck in the release helper
+unless CI can consume a versioned ShellCheck binary without adding another
+mutable installer.
+
+### 4.3 Repository Action allowlist
+
+This is a GitHub setting applied in Task 6, but add local tests now that produce
+the expected inventory.
+
+Desired repository policy:
+
+- `allowed_actions: selected`
+- `sha_pinning_required: true`
+- GitHub-owned actions allowed
+- all verified publishers **not** allowed as a blanket category
+- explicit third-party repository patterns:
+  - `astral-sh/setup-uv@*`
+  - `codecov/codecov-action@*`
+  - `dependabot/fetch-metadata@*`
+  - `ossf/scorecard-action@*`
+  - `pypa/gh-action-pypi-publish@*`
+  - `softprops/action-gh-release@*`
+
+The allowlist identifies approved action repositories; the separate SHA policy
+ensures every actual reference remains immutable.
+
+### PR C gate
+
+Open PR C with Task 4 only. Require Test and CodeQL on the PR head. Confirm the
+local 85% coverage command is a hard gate, the Codecov OIDC attempt is visible,
+and the example pytest/mypy commands run from the frozen environment. If the
+Codecov service itself is unavailable, the PR may merge after the explicit
+warning path is observed and local coverage passes; keep the Codecov evidence
+row pending until a later authenticated upload succeeds.
+
+## Task 5: Verify the Three Merged Slices Together
+
+### Steps
+
+1. Confirm PR A contains only Tasks 1-2, PR B only Task 3, and PR C only Task 4.
+   Do not squash all three concerns into a replacement mega-PR if one slice
+   needs revision.
+2. Require these workflows to finish on the final merged `main` SHA:
+
+   - Test
+   - Test Postgres Extension
+   - Test Redis Extension
+   - CodeQL
+
+3. Manually run the fuzz workflow on the PR A head and again on the final
+   merged `main` SHA because lock and uv behavior changed.
+4. Confirm both 15-minute fuzz harnesses pass.
+5. Confirm packaging smoke prints exact locked build-tool versions.
+6. Confirm at least one PR or `main` Codecov upload succeeds through OIDC. If
+   Codecov is externally unavailable, do not block merging otherwise-green
+   slices; leave rollout evidence pending and capture the warning-bearing run.
+7. Confirm all three `uv lock --check` commands pass in CI.
+8. Review the final diff for runtime behavior changes. Changes to
+   `simplebroker/_scripts.py` must be limited to developer/test/packaging command
+   construction.
+9. If a required gate is red, stop the settings rollout and fix the problem in
+   a focused follow-up assigned to the responsible PR slice. A warning caused
+   solely by external Codecov availability may leave the Codecov rollout row
+   pending, but does not redefine the repository gates.
+
+### Gate
+
+The final merged `main` contains reproducible builds, the pre-tag exact-SHA
+gate, shared immutable-compatible publication workflows, and independent CI
+quick wins before any immutable release or tag setting is enabled. Each PR has
+its own green evidence, and the combined `main` SHA is also green.
+
+## Task 6: Apply GitHub Settings in Safe Order
+
+These are external state changes. Capture the before JSON and apply one setting
+at a time. Read it back before proceeding. Do not start until PRs A, B, and C
+are merged, the combined `main` SHA is green, and the merged release-helper dry
+run shows `push main -> exact-SHA CI -> create tag`. No real release is allowed
+in the transition window because the merged settings preflight intentionally
+fails until this task is complete.
+
+### 6.1 Enforce selected, SHA-pinned Actions
+
+1. Set repository Actions permissions to:
+
+   ```json
+   {
+     "enabled": true,
+     "allowed_actions": "selected",
+     "sha_pinning_required": true
+   }
+   ```
+
+2. Set selected actions to GitHub-owned plus the six explicit third-party
+   patterns from Task 4.3.
+3. Dispatch `Test`, CodeQL, Scorecard, and Fuzz far enough to prove every action
+   is admitted. Do not wait for fuzz completion before checking that both jobs
+   start successfully; still require final fuzz success before completion.
+4. If an action is blocked, add only that exact repository pattern. Do not
+   enable all verified actions as a shortcut.
+
+### 6.2 Restrict the `pypi` environment to release tags
+
+First update the existing `pypi` environment to enable custom deployment
+policies:
+
+```json
+{
+  "deployment_branch_policy": {
+    "protected_branches": false,
+    "custom_branch_policies": true
+  }
+}
+```
+
+Then create these custom deployment tag policies, with no branch policies:
+
+- type `tag`, name `v*`
+- type `tag`, name `simplebroker_pg/v*`
+- type `tag`, name `simplebroker_redis/v*`
+
+Do not add required reviewers. The environment restriction is an automated ref
+check, not a team approval process.
+
+Read back:
+
+```bash
+gh api -H 'X-GitHub-Api-Version: 2026-03-10' \
+  /repos/VanL/simplebroker/environments/pypi
+gh api -H 'X-GitHub-Api-Version: 2026-03-10' \
+  /repos/VanL/simplebroker/environments/pypi/deployment-branch-policies
+```
+
+### 6.3 Add a write-once release-tag ruleset
+
+Create one active tag ruleset named `Protect release tags` covering:
+
+- `refs/tags/v*`
+- `refs/tags/simplebroker_pg/v*`
+- `refs/tags/simplebroker_redis/v*`
+
+Rules:
+
+- restrict updates
+- restrict deletions
+- do **not** restrict creation
+- no bypass actors
+
+Do not test this with a destructive force-push. Verify through the ruleset API
+readback and the release helper's unit tests. The no-bypass policy is acceptable
+only because Task 3 moved candidate validation before final tag creation.
+
+### 6.4 Enable immutable releases last
+
+Use repository Settings -> General -> Releases -> Enable release immutability,
+or the corresponding repository API.
+
+Read back:
+
+```bash
+gh api -H 'X-GitHub-Api-Version: 2026-03-10' \
+  /repos/VanL/simplebroker/immutable-releases
+```
+
+Expected: `enabled: true`.
+
+Then run:
+
+```bash
+uv run python bin/release.py --check-repository-settings
+```
+
+Expected: one success line for immutable releases, tag rules, environment tag
+policies, and Actions SHA enforcement.
+
+## Task 7: Final Verification and First-Release Evidence
+
+### Local gates
+
+```bash
+python bin/bump_uv.py --check
+uv run pytest -q -n0 \
+  tests/test_bump_uv.py \
+  tests/test_release_publication_script.py \
+  tests/test_release_workflow.py \
+  tests/test_release_script.py \
+  tests/test_dev_scripts.py
+uv run pytest
+uv run ruff check simplebroker tests bin .github/scripts \
+  extensions/simplebroker_pg/simplebroker_pg \
+  extensions/simplebroker_pg/tests \
+  extensions/simplebroker_redis/simplebroker_redis \
+  extensions/simplebroker_redis/tests
+uv run ruff format --check simplebroker tests bin .github/scripts \
+  extensions/simplebroker_pg/simplebroker_pg \
+  extensions/simplebroker_pg/tests \
+  extensions/simplebroker_redis/simplebroker_redis \
+  extensions/simplebroker_redis/tests
+uv run mypy simplebroker bin/release.py bin/bump_uv.py \
+  .github/scripts/require_green_workflows.py \
+  .github/scripts/release_publication.py \
+  extensions/simplebroker_pg/simplebroker_pg \
+  extensions/simplebroker_redis/simplebroker_redis \
+  --config-file pyproject.toml
+uv run ./bin/packaging-smoke --python 3.11
+uv run python bin/release.py --dry-run
+uv run python bin/release.py --check-repository-settings
+git diff --check
+git status --short
+```
+
+### GitHub gates
+
+- Test passes on `main`
+- Postgres extension passes on `main`
+- Redis extension passes on `main`
+- CodeQL passes with zero new alerts
+- Scorecard uploads successfully
+- both fuzz harnesses pass
+- at least one Codecov upload is authenticated with OIDC and succeeds; any
+  later upload failure is an explicit warning while the local 85% gate remains
+  hard
+- Actions settings show selected actions plus required SHA pinning
+- `pypi` environment shows only the three tag policies
+- tag ruleset shows update/deletion restrictions and no bypass
+- immutable releases endpoint reports enabled
+
+### First real release proof
+
+Do not create a throwaway PyPI version solely to test this plan. The next normal
+package release is the live publication proof.
+
+For that release, record:
+
+1. release commit SHA pushed to `main`
+2. required Test, PG, and/or Redis workflow URLs for that exact SHA, with
+   completion times before the tag-push event
+3. helper output showing the pre-tag gate succeeded
+4. tag name and confirmation that it points to the same immutable commit SHA
+5. release workflow URL and its defense-in-depth required-test readback
+6. build log showing exact uv, build, and Hatchling versions
+7. draft release created with wheel, sdist, and Sigstore bundle before PyPI
+8. successful Trusted Publishing job with no token
+9. final GitHub Release marked immutable
+10. GitHub release attestation plus repository-generated Sigstore bundle
+11. PyPI version and files matching the workflow artifacts
+
+If PyPI succeeds but final GitHub publication fails, rerun the final job against
+the existing draft. Do not move the tag or rebuild different artifacts.
+
+## Rollback Strategy
+
+### Before a real release
+
+- Repository code: revert the affected PR slice or slices; do not revert all
+  three if the failure is isolated to one.
+- Actions allowlist: restore the captured `allowed_actions: all` policy only if
+  the selected policy blocks required workflows and the exact missing action
+  cannot be identified promptly.
+- Environment policy: restore `deployment_branch_policy: null` only if the tag
+  patterns are proven incorrect; fix patterns and re-enable immediately.
+- Tag ruleset: disable only before a new protected release tag is used and only
+  to repair configuration, not to move a release tag.
+- Immutable releases: disable for future releases only if the draft-first flow
+  is incompatible in practice. Do not assume already-immutable releases become
+  mutable.
+
+### After tag push, before PyPI publication
+
+The tag is already a public, immutable identity even though PyPI has no version
+yet.
+
+- retry transient hosted-workflow, draft, attestation, or Trusted Publishing
+  configuration failures against the same tag and SHA
+- delete and recreate only a draft release through the shared script; never
+  change the tag or rebuild from a different commit
+- if recovery requires a source change, leave the old tag untouched and use a
+  new patch version for the corrected commit
+
+### After PyPI publication
+
+There is no rollback that reuses the version or tag.
+
+- never overwrite the tag
+- never replace release assets
+- never republish different bits under the same version
+- fix forward with a new patch release
+- use PyPI yank only when users should avoid the bad release; yanking is not a
+  substitute for publishing corrected artifacts
+
+## Failure-Mode Matrix
+
+| Failure | Expected behavior | Recovery |
+|---|---|---|
+| Root or extension lock is stale | CI fails before tests | Regenerate the intended lock, review diff, rerun |
+| Locked dependency unavailable | Sync/build fails; no fallback resolution | Investigate index/outage; do not remove `--frozen` |
+| Release cache absent | Build downloads locked artifacts and succeeds | No action; this is expected |
+| Repository-settings preflight fails | Release stops before version files or git state change | Correct the setting and rerun the same version |
+| Pre-tag required CI fails, is cancelled, is missing, or times out | Release commit remains on `main`; no final tag is created or pushed | Fix `main` and rerun the helper with the same unpublished version |
+| `main` fast-forwards during the pre-tag wait but still contains the stored release SHA | Helper tags the stored, already-green release SHA | No action; unrelated later commits do not invalidate the tested release commit |
+| The stored release SHA is no longer reachable from `origin/main` after the pre-tag wait | Helper fails the ancestry recheck and creates no tag | Put the intended release commit back on `main` through a normal forward change, let exact-SHA CI pass, and rerun |
+| Draft creation fails | PyPI job does not run | Fix GitHub release job and rerun |
+| Artifact upload to draft fails | PyPI job does not run | Rerun draft-staging job |
+| PyPI Trusted Publishing fails | Draft remains unpublished | Fix publisher/environment configuration and rerun same workflow/tag |
+| Final release publication fails after PyPI succeeds | PyPI version exists; draft remains | Rerun final job; do not rebuild or retag |
+| Remote tag exists at the wrong SHA | Release helper and workflow fail closed | Choose a new version; never retag |
+| Post-tag failure requires a code change | Existing tag and version remain bound to their original SHA | Commit the fix and publish a new patch version |
+| Wrong tag pattern targets `pypi` | Deployment is rejected before OIDC publish | Correct environment tag pattern; rerun |
+| Action allowlist blocks a workflow | Workflow fails before the action starts | Add the exact action repository pattern, retain SHA enforcement |
+| Codecov OIDC or service upload fails | Upload step records failure and emits a warning; local 85% coverage gate still controls the job | Fix persistent OIDC/configuration errors; rerun opportunistically for an outage; do not add a token or block unrelated green work |
+| GitHub immutable release is published with wrong assets | Assets cannot be replaced | Publish a corrected patch release; do not weaken immutability |
+
+## Common Wrong Turns
+
+- Do not add a PyPI token because Trusted Publishing already works.
+- Do not enable immutable releases before the draft-first workflow lands.
+- Do not protect tag creation; the release helper must still create new tags.
+- Do not leave `--retag` as an undocumented escape hatch.
+- Do not push the final release tag to discover whether cross-platform CI is
+  green; the exact-SHA gate belongs before tag creation.
+- Do not use `--frozen` without a separate lock-freshness gate and then claim a
+  stale lock is valid.
+- Do not update the uv range, seven workflow pins, and three locks by hand; use
+  `bin/bump_uv.py`, review its diff, and run its check mode.
+- Do not keep extension locks if CI never checks them.
+- Do not replace live `uv pip install` with a different live resolver command.
+- Do not use `uv run --with build` in packaging or release paths.
+- Do not enable all verified Marketplace actions to avoid maintaining six
+  explicit patterns.
+- Do not add human release approval to solve a machine-verifiable ref problem.
+- Do not pin an exact build backend in published `[build-system].requires`;
+  exactness belongs in the release group and lock.
+- Do not rely on the release action to find and update an existing draft by
+  tag; delete any stale draft and recreate it.
+- Do not copy release discovery, draft deletion, PyPI polling, or final
+  publication API logic into three YAML files; call the shared checked-in
+  script while preserving the three top-level workflow identities.
+- Do not touch Windows timing factors or contention tests in this work.
+- Do not turn Codecov reporting availability into the hard coverage gate; the
+  local 85% report is the gate and Codecov failures must be visible warnings.
+- Do not move publication into a reusable workflow without first changing the
+  PyPI trusted-publisher identities; that is explicitly out of scope.
+
+## Acceptance Criteria
+
+1. `uv lock --check` passes for root, PG, and Redis without modifying files.
+2. `python bin/bump_uv.py --check` proves the supported local uv range and every
+   workflow `UV_VERSION` agree; dry-run and failure tests prove the updater is
+   atomic and fail-closed.
+3. Every setup-uv step references its workflow's shared `UV_VERSION`.
+4. Normal CI contains no `uv pip install`, `pip install`, or ephemeral editable
+   dependency overlay.
+5. Test, lint, coverage, PG, and Redis jobs consume the checked-in root lock.
+6. Packaging smoke and all release builds use exact locked `build` and
+   `hatchling` versions with build isolation disabled.
+7. Release workflows explicitly disable setup-uv caching.
+8. Root and all extension artifacts still build, install, expose licenses, and
+   register backend entry points.
+9. Trusted Publishing remains tokenless and bound to the existing three
+   workflow files plus the `pypi` environment.
+10. A real release runs only from `main`, pushes the release commit first, and
+    requires the target-specific normal workflows to pass on that exact SHA
+    before any final tag is created or pushed; immediately before tagging, the
+    stored SHA must still be reachable from freshly fetched `origin/main`.
+11. Failed or missing pre-tag CI creates no tag and the same unpublished
+    version can be retried after fixing `main`.
+12. Remote release tags cannot be moved or deleted and the helper has no
+    `--retag` path.
+13. A transient post-tag publication failure can rerun only at the same tag and
+    SHA; a recovery requiring new code uses a new patch version.
+14. All three release workflows call one shared publication-state script; no
+    workflow duplicates draft discovery/deletion, PyPI lag polling, or final
+    publication API logic.
+15. Every release stages all assets on a draft before PyPI publication.
+16. A GitHub Release becomes published only after PyPI succeeds.
+17. The `pypi` environment accepts only the three documented tag families.
+18. GitHub enforces full-SHA Actions references and admits only GitHub-owned
+    actions plus the six explicit third-party action repositories.
+19. Future GitHub Releases are immutable.
+20. Codecov uses OIDC and has at least one successful authenticated rollout
+    upload; later upload errors produce an explicit warning without overriding
+    the local coverage result.
+21. Local combined coverage below 85% fails the coverage job independently of
+    Codecov.
+22. Python examples run under normal CI.
+23. PRs A, B, and C each have focused green evidence, and full core, PG, Redis,
+    packaging, CodeQL, Scorecard, and fuzz gates pass on the combined `main` SHA.
+24. No queue, watcher, backend, retry, timing, or public runtime behavior changes.
+
+## Completion Evidence
+
+Fill this table during implementation. A GitHub-setting row is not complete
+from YAML or local tests alone.
+
+| Slice | Status | Evidence |
+|---|---|---|
+| Baseline captured | Pending | Starting SHA, lock outcomes, settings JSON, green run URLs |
+| PR A: reproducible builds | Pending | Focused PR diff, normal workflow URLs, and both fuzz results |
+| uv bump automation | Pending | `bin/bump_uv.py --check`, dry-run output, and updater unit tests |
+| Locks current | Pending | Three successful `uv lock --check` outputs and reviewed lock diff |
+| Frozen CI | Pending | PR workflow URLs and tests proving no live resolver path |
+| Locked build frontend | Pending | Packaging log with exact uv/build/Hatchling versions |
+| Cache-free release builds | Pending | Workflow diff plus PR structural tests |
+| PR B: publication flow | Pending | Focused PR diff, release-helper tests, shared-script tests, and merged dry-run order |
+| Pre-tag exact-SHA gate | Pending | Command-order tests plus first-release workflow timestamps before tag creation |
+| Write-once release helper | Pending | Unit tests; no `--retag` or remote delete command; final tag created only after CI |
+| Shared draft-first release flow | Pending | Shared-script tests and all three merged job dependency graphs |
+| PR C: CI quick wins | Pending | Focused PR diff, coverage/example workflow output, and warning-path test |
+| Codecov OIDC | Pending | At least one successful authenticated PR or `main` upload URL; warning-bearing outage run if encountered |
+| Example CI | Pending | `pytest -n0 examples` and example mypy job output |
+| Actions policy | Pending | Authenticated permissions and selected-actions readback |
+| PyPI environment policy | Pending | Environment and tag-policy readback |
+| Release tag ruleset | Pending | Active tag ruleset readback with no bypass |
+| Immutable releases | Pending | Repository API returns `enabled: true` |
+| Repository-settings preflight | Pending | `bin/release.py --check-repository-settings` output |
+| First immutable release | Pending until next normal release | Workflow, PyPI, immutable GitHub Release, and attestation URLs |
+
+## Fresh-Eyes Review Checklist
+
+- Does any normal CI path still resolve dependencies outside a checked lock?
+- Can a stale extension lock pass every workflow?
+- Does any packaging or release build create an isolated environment that
+  resolves Hatchling live?
+- Can a release build restore an Actions cache?
+- Can the release helper create or push a final tag before the target-specific
+  workflows are green on the exact release SHA contained in `main`?
+- Does a pre-tag CI failure leave any local or remote tag behind, or prevent
+  reuse of the still-unpublished version?
+- Can any remote release tag be deleted or moved by the helper or GitHub rules?
+- Are all assets present before an immutable release is published?
+- Can a rerun of draft staging leave duplicate drafts for one tag?
+- Is any release discovery, draft deletion, PyPI polling, or final-publication
+  state machine duplicated across the three workflow YAML files?
+- Can PyPI run before draft asset staging succeeds?
+- Can final GitHub publication run before PyPI succeeds?
+- Can a branch, pull request ref, or unrelated tag deploy to `pypi`?
+- Can a non-SHA action reference start in Actions?
+- Can Codecov upload fail without an explicit warning?
+- Can Codecov availability override the local 85% coverage result?
+- Did any change weaken Trusted Publishing or add a long-lived secret?
+- Did any change alter contention, timing, queue, watcher, or backend behavior?

--- a/extensions/simplebroker_pg/pyproject.toml
+++ b/extensions/simplebroker_pg/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling>=1.31,<2"]
 build-backend = "hatchling.build"
 
 [project]

--- a/extensions/simplebroker_pg/uv.lock
+++ b/extensions/simplebroker_pg/uv.lock
@@ -182,7 +182,11 @@ requires-dist = [
 provides-extras = ["dev", "pg", "redis"]
 
 [package.metadata.requires-dev]
-fuzz = [{ name = "atheris", specifier = ">=2.3.0" }]
+fuzz = [{ name = "atheris", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'", specifier = ">=2.3.0" }]
+release = [
+    { name = "build", specifier = "==1.5.1" },
+    { name = "hatchling", specifier = "==1.31.0" },
+]
 
 [[package]]
 name = "simplebroker-pg"

--- a/extensions/simplebroker_redis/pyproject.toml
+++ b/extensions/simplebroker_redis/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling>=1.31,<2"]
 build-backend = "hatchling.build"
 
 [project]

--- a/extensions/simplebroker_redis/uv.lock
+++ b/extensions/simplebroker_redis/uv.lock
@@ -122,7 +122,11 @@ requires-dist = [
 provides-extras = ["dev", "pg", "redis"]
 
 [package.metadata.requires-dev]
-fuzz = [{ name = "atheris", specifier = ">=2.3.0" }]
+fuzz = [{ name = "atheris", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'", specifier = ">=2.3.0" }]
+release = [
+    { name = "build", specifier = "==1.5.1" },
+    { name = "hatchling", specifier = "==1.31.0" },
+]
 
 [[package]]
 name = "simplebroker-redis"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling>=1.31,<2"]
 build-backend = "hatchling.build"
 
 [project]
@@ -58,6 +58,10 @@ redis = [
 fuzz = [
     "atheris>=2.3.0; sys_platform == 'linux' and platform_machine == 'x86_64'",
 ]
+release = [
+    "build==1.5.1",
+    "hatchling==1.31.0",
+]
 
 [project.scripts]
 broker = "simplebroker.cli:main"
@@ -70,6 +74,7 @@ Repository = "https://github.com/VanL/simplebroker.git"
 Issues = "https://github.com/VanL/simplebroker/issues"
 
 [tool.uv]
+required-version = ">=0.11.11,<0.12"
 default-groups = []
 
 [tool.uv.sources]

--- a/simplebroker/_scripts.py
+++ b/simplebroker/_scripts.py
@@ -281,12 +281,13 @@ def _pg_test_uv_command(*args: str) -> list[str]:
     return [
         "uv",
         "run",
+        "--project",
+        str(ROOT),
+        "--locked",
         "--extra",
         "dev",
-        "--with-editable",
-        ".",
-        "--with-editable",
-        "./extensions/simplebroker_pg[dev]",
+        "--extra",
+        "pg",
         *args,
     ]
 
@@ -688,8 +689,21 @@ def _remove_build_outputs() -> None:
 
 def _build_distribution(project_dir: Path) -> None:
     _run(
-        ["uv", "run", "--with", "build", "python", "-m", "build"],
-        cwd=project_dir,
+        [
+            "uv",
+            "run",
+            "--project",
+            str(ROOT),
+            "--locked",
+            "--group",
+            "release",
+            "python",
+            "-m",
+            "build",
+            "--no-isolation",
+            str(project_dir),
+        ],
+        cwd=ROOT,
     )
 
 

--- a/tests/test_bump_uv.py
+++ b/tests/test_bump_uv.py
@@ -1,0 +1,267 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from importlib import util
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPOSITORY_ROOT / "bin" / "bump_uv.py"
+WORKFLOWS = (
+    "fuzz.yml",
+    "release-gate.yml",
+    "release-gate-pg.yml",
+    "release-gate-redis.yml",
+    "test.yml",
+    "test-pg-extension.yml",
+    "test-redis-extension.yml",
+)
+
+
+@pytest.fixture
+def repository(tmp_path: Path) -> Path:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text("[tool.uv]\ndefault-groups = []\n")
+
+    workflow_dir = tmp_path / ".github" / "workflows"
+    workflow_dir.mkdir(parents=True)
+    for name in WORKFLOWS:
+        (workflow_dir / name).write_text("name: Test\n\njobs: {}\n")
+
+    for directory in (
+        tmp_path,
+        tmp_path / "extensions" / "simplebroker_pg",
+        tmp_path / "extensions" / "simplebroker_redis",
+    ):
+        directory.mkdir(parents=True, exist_ok=True)
+        (directory / "uv.lock").write_text("old lock\n")
+    return tmp_path
+
+
+@pytest.fixture
+def bump_uv_module() -> ModuleType:
+    spec = util.spec_from_file_location("bump_uv", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_dry_run_reports_every_managed_file_without_writing(
+    repository: Path,
+) -> None:
+    pyproject = repository / "pyproject.toml"
+    workflow_dir = repository / ".github" / "workflows"
+    before = {
+        path: path.read_bytes()
+        for path in (pyproject, *(workflow_dir / name for name in WORKFLOWS))
+    }
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--root",
+            str(repository),
+            "--ci-version",
+            "0.11.28",
+            "--required-version",
+            ">=0.11.28,<0.12",
+            "--dry-run",
+        ],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "pyproject.toml" in result.stdout
+    for name in WORKFLOWS:
+        assert name in result.stdout
+    assert {path: path.read_bytes() for path in before} == before
+
+
+def test_update_and_check_cover_every_lock(
+    repository: Path,
+    bump_uv_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    calls: list[list[str]] = []
+
+    def run(command: list[str], *, cwd: Path, check: bool) -> None:
+        assert cwd == repository
+        assert check is True
+        calls.append(command)
+
+    monkeypatch.setattr(bump_uv_module.subprocess, "run", run)
+
+    result = bump_uv_module.main(
+        [
+            "--root",
+            str(repository),
+            "--ci-version",
+            "0.11.28",
+            "--required-version",
+            ">=0.11.28,<0.12",
+        ]
+    )
+
+    assert result == 0
+    assert (
+        'required-version = ">=0.11.28,<0.12"'
+        in (repository / "pyproject.toml").read_text()
+    )
+    for name in WORKFLOWS:
+        workflow = repository / ".github" / "workflows" / name
+        assert workflow.read_text().count('UV_VERSION: "0.11.28"') == 1
+        assert "\njobs: {}\n" in workflow.read_text()
+    assert calls == [
+        ["uv", "lock"],
+        ["uv", "lock", "--directory", "extensions/simplebroker_pg"],
+        ["uv", "lock", "--directory", "extensions/simplebroker_redis"],
+        ["uv", "lock", "--check"],
+        [
+            "uv",
+            "lock",
+            "--directory",
+            "extensions/simplebroker_pg",
+            "--check",
+        ],
+        [
+            "uv",
+            "lock",
+            "--directory",
+            "extensions/simplebroker_redis",
+            "--check",
+        ],
+    ]
+
+    capsys.readouterr()
+    assert (
+        bump_uv_module.main(
+            [
+                "--root",
+                str(repository),
+                "--ci-version",
+                "0.11.28",
+                "--required-version",
+                ">=0.11.28,<0.12",
+                "--dry-run",
+            ]
+        )
+        == 0
+    )
+    dry_run_output = capsys.readouterr().out
+    assert "would update" not in dry_run_output
+    assert dry_run_output.count("unchanged") == len(WORKFLOWS) + 1
+
+    assert bump_uv_module.main(["--root", str(repository), "--check"]) == 0
+    assert calls[-3:] == [
+        ["uv", "lock", "--check"],
+        [
+            "uv",
+            "lock",
+            "--directory",
+            "extensions/simplebroker_pg",
+            "--check",
+        ],
+        [
+            "uv",
+            "lock",
+            "--directory",
+            "extensions/simplebroker_redis",
+            "--check",
+        ],
+    ]
+
+
+def test_failed_lock_refresh_restores_manifests_and_locks(
+    repository: Path, bump_uv_module: ModuleType, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    managed_paths = (
+        repository / "pyproject.toml",
+        *(repository / ".github" / "workflows" / name for name in WORKFLOWS),
+        repository / "uv.lock",
+        repository / "extensions" / "simplebroker_pg" / "uv.lock",
+        repository / "extensions" / "simplebroker_redis" / "uv.lock",
+    )
+    before = {path: path.read_bytes() for path in managed_paths}
+    call_count = 0
+
+    def fail_during_lock_refresh(command: list[str], *, cwd: Path, check: bool) -> None:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            (repository / "uv.lock").write_text("changed lock\n")
+            return
+        raise subprocess.CalledProcessError(1, command)
+
+    monkeypatch.setattr(bump_uv_module.subprocess, "run", fail_during_lock_refresh)
+
+    result = bump_uv_module.main(
+        [
+            "--root",
+            str(repository),
+            "--ci-version",
+            "0.11.28",
+            "--required-version",
+            ">=0.11.28,<0.12",
+        ]
+    )
+
+    assert result == 1
+    assert {path: path.read_bytes() for path in managed_paths} == before
+
+
+@pytest.mark.parametrize("problem", ["missing_jobs", "duplicate_pin", "unmanaged"])
+def test_invalid_workflow_sets_fail_before_writing(
+    repository: Path,
+    bump_uv_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    problem: str,
+) -> None:
+    workflow_dir = repository / ".github" / "workflows"
+    if problem == "missing_jobs":
+        (workflow_dir / "test.yml").write_text("name: Test\n")
+    elif problem == "duplicate_pin":
+        (workflow_dir / "test.yml").write_text(
+            'name: Test\n\nenv:\n  UV_VERSION: "0.11.27"\n'
+            '  UV_VERSION: "0.11.28"\n\njobs: {}\n'
+        )
+    else:
+        (workflow_dir / "unmanaged.yml").write_text(
+            "name: Unmanaged\nsteps:\n  - uses: astral-sh/setup-uv@abc\n"
+        )
+
+    managed_paths = (
+        repository / "pyproject.toml",
+        *(workflow_dir / name for name in WORKFLOWS),
+        repository / "uv.lock",
+        repository / "extensions" / "simplebroker_pg" / "uv.lock",
+        repository / "extensions" / "simplebroker_redis" / "uv.lock",
+    )
+    before = {path: path.read_bytes() for path in managed_paths}
+    calls: list[list[str]] = []
+    monkeypatch.setattr(
+        bump_uv_module.subprocess,
+        "run",
+        lambda command, **kwargs: calls.append(command),
+    )
+
+    result = bump_uv_module.main(
+        [
+            "--root",
+            str(repository),
+            "--ci-version",
+            "0.11.28",
+            "--required-version",
+            ">=0.11.28,<0.12",
+        ]
+    )
+
+    assert result == 1
+    assert calls == []
+    assert {path: path.read_bytes() for path in managed_paths} == before

--- a/tests/test_bump_uv.py
+++ b/tests/test_bump_uv.py
@@ -120,21 +120,21 @@ def test_update_and_check_cover_every_lock(
         assert "\njobs: {}\n" in workflow.read_text()
     assert calls == [
         ["uv", "lock"],
-        ["uv", "lock", "--directory", "extensions/simplebroker_pg"],
-        ["uv", "lock", "--directory", "extensions/simplebroker_redis"],
+        ["uv", "lock", "--directory", str(Path("extensions/simplebroker_pg"))],
+        ["uv", "lock", "--directory", str(Path("extensions/simplebroker_redis"))],
         ["uv", "lock", "--check"],
         [
             "uv",
             "lock",
             "--directory",
-            "extensions/simplebroker_pg",
+            str(Path("extensions/simplebroker_pg")),
             "--check",
         ],
         [
             "uv",
             "lock",
             "--directory",
-            "extensions/simplebroker_redis",
+            str(Path("extensions/simplebroker_redis")),
             "--check",
         ],
     ]
@@ -165,14 +165,14 @@ def test_update_and_check_cover_every_lock(
             "uv",
             "lock",
             "--directory",
-            "extensions/simplebroker_pg",
+            str(Path("extensions/simplebroker_pg")),
             "--check",
         ],
         [
             "uv",
             "lock",
             "--directory",
-            "extensions/simplebroker_redis",
+            str(Path("extensions/simplebroker_redis")),
             "--check",
         ],
     ]

--- a/tests/test_dev_scripts.py
+++ b/tests/test_dev_scripts.py
@@ -443,12 +443,31 @@ def test_pg_test_uv_command_uses_pg_test_dependencies() -> None:
     assert _pg_test_uv_command("pytest", "tests") == [
         "uv",
         "run",
+        "--project",
+        str(REPO_ROOT),
+        "--locked",
         "--extra",
         "dev",
-        "--with-editable",
-        ".",
-        "--with-editable",
-        "./extensions/simplebroker_pg[dev]",
+        "--extra",
+        "pg",
+        "pytest",
+        "tests",
+    ]
+
+
+def test_redis_test_uv_command_uses_the_locked_root_project() -> None:
+    redis_script = runpy.run_path(str(REPO_ROOT / "bin" / "pytest-redis"))
+
+    assert redis_script["_uv_command"]("pytest", "tests") == [
+        "uv",
+        "run",
+        "--project",
+        str(REPO_ROOT),
+        "--locked",
+        "--extra",
+        "dev",
+        "--extra",
+        "redis",
         "pytest",
         "tests",
     ]
@@ -469,18 +488,19 @@ def test_verify_postgres_test_dsn_runs_select_one(
 
     assert len(calls) == 1
     cmd, env, capture_output = calls[0]
-    assert cmd[:8] == [
+    assert cmd[:9] == [
         "uv",
         "run",
+        "--project",
+        str(REPO_ROOT),
+        "--locked",
         "--extra",
         "dev",
-        "--with-editable",
-        ".",
-        "--with-editable",
-        "./extensions/simplebroker_pg[dev]",
+        "--extra",
+        "pg",
     ]
-    assert cmd[8:10] == ["python", "-c"]
-    assert cmd[10] == _scripts._POSTGRES_DSN_VERIFY_COMMAND
+    assert cmd[9:11] == ["python", "-c"]
+    assert cmd[11] == _scripts._POSTGRES_DSN_VERIFY_COMMAND
     assert env is not None
     assert env["SIMPLEBROKER_PG_TEST_DSN"] == "postgresql://example/test"
     assert env["SIMPLEBROKER_PG_TEST_DSN_READY_TIMEOUT"] == "60.000000"
@@ -602,7 +622,7 @@ def test_pytest_pg_main_preflights_dsn_before_pytest(
     assert calls[0] == ("verify", "postgresql://example/test")
     run_call = calls[1]
     assert run_call[0] == "run"
-    assert run_call[1][8:10] == ["pytest", "tests/test_smoke.py"]
+    assert run_call[1][9:11] == ["pytest", "tests/test_smoke.py"]
     assert run_call[2]["SIMPLEBROKER_PG_TEST_DSN"] == "postgresql://example/test"
     assert run_call[2]["BROKER_TEST_BACKEND"] == "postgres"
     assert calls[2] == ("cleanup", "pg-container")
@@ -852,6 +872,41 @@ def test_packaging_smoke_main_builds_and_smoke_installs(
     assert run_calls[2][1][1] == "-c"
     assert "get_backend_plugin('postgres')" in run_calls[2][1][2]
     assert "get_backend_plugin('redis')" in run_calls[2][1][2]
+
+
+def test_build_distribution_uses_locked_nonisolated_frontend(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = []
+    project_dir = REPO_ROOT / "extensions" / "simplebroker_pg"
+
+    def fake_run(cmd, *, cwd=_scripts.ROOT, env=None, capture_output=False):
+        calls.append((cmd, cwd))
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(_scripts, "_run", fake_run)
+
+    _scripts._build_distribution(project_dir)
+
+    assert calls == [
+        (
+            [
+                "uv",
+                "run",
+                "--project",
+                str(REPO_ROOT),
+                "--locked",
+                "--group",
+                "release",
+                "python",
+                "-m",
+                "build",
+                "--no-isolation",
+                str(project_dir),
+            ],
+            REPO_ROOT,
+        )
+    ]
 
 
 def test_packaging_smoke_main_returns_subprocess_failure(

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -3,6 +3,25 @@ import tomllib
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
+UV_WORKFLOWS = (
+    "fuzz.yml",
+    "release-gate.yml",
+    "release-gate-pg.yml",
+    "release-gate-redis.yml",
+    "test.yml",
+    "test-pg-extension.yml",
+    "test-redis-extension.yml",
+)
+TEST_WORKFLOWS = (
+    "test.yml",
+    "test-pg-extension.yml",
+    "test-redis-extension.yml",
+)
+RELEASE_WORKFLOWS = (
+    "release-gate.yml",
+    "release-gate-pg.yml",
+    "release-gate-redis.yml",
+)
 
 
 def _workflow_text(path: str) -> str:
@@ -68,6 +87,72 @@ def test_fuzz_dependency_group_is_opt_in() -> None:
         "atheris>=2.3.0; sys_platform == 'linux' and platform_machine == 'x86_64'"
     ]
     assert pyproject["tool"]["uv"]["default-groups"] == []
+
+
+def test_every_uv_workflow_uses_the_repository_pin() -> None:
+    for workflow_path in UV_WORKFLOWS:
+        workflow_text = _workflow_text(workflow_path)
+
+        assert workflow_text.count('UV_VERSION: "0.11.28"') == 1
+        assert re.search(r"(?m)^jobs:\n  [a-z]", workflow_text)
+        setup_count = workflow_text.count("uses: astral-sh/setup-uv@")
+        assert setup_count > 0
+        assert workflow_text.count("version: ${{ env.UV_VERSION }}") == setup_count
+
+
+def test_test_workflows_sync_once_and_only_run_the_frozen_environment() -> None:
+    expected_extras = {
+        "test.yml": (
+            "uv sync --frozen --extra dev",
+            "uv sync --frozen --extra dev --extra pg --extra redis",
+        ),
+        "test-pg-extension.yml": ("uv sync --frozen --extra dev --extra pg",),
+        "test-redis-extension.yml": ("uv sync --frozen --extra dev --extra redis",),
+    }
+
+    for workflow_path in TEST_WORKFLOWS:
+        workflow_text = _workflow_text(workflow_path)
+
+        assert "uv pip install" not in workflow_text
+        for sync_command in expected_extras[workflow_path]:
+            assert sync_command in workflow_text
+        for line in workflow_text.splitlines():
+            command = line.strip()
+            if command.startswith(("uv run ", "uv run ./")):
+                assert command.startswith("uv run --frozen --no-sync ")
+
+
+def test_release_builds_use_the_exact_locked_frontend_without_a_cache() -> None:
+    for workflow_path in RELEASE_WORKFLOWS:
+        workflow_text = _workflow_text(workflow_path)
+
+        build_section = workflow_text.split("      - name: Install uv", 1)[1].split(
+            "      - name: Generate artifact attestation", 1
+        )[0]
+        assert "enable-cache: false" in build_section
+        assert "uv sync --frozen --group release" in build_section
+        assert (
+            'uv run --frozen --no-sync python -m build --no-isolation "${PACKAGE_DIR}"'
+        ) in build_section
+        assert "uv build" not in build_section
+        assert "working-directory:" not in build_section
+
+
+def test_build_frontend_is_bounded_and_locked() -> None:
+    projects = (
+        ROOT / "pyproject.toml",
+        ROOT / "extensions" / "simplebroker_pg" / "pyproject.toml",
+        ROOT / "extensions" / "simplebroker_redis" / "pyproject.toml",
+    )
+    for path in projects:
+        pyproject = tomllib.loads(path.read_text(encoding="utf-8"))
+        assert pyproject["build-system"]["requires"] == ["hatchling>=1.31,<2"]
+
+    root_pyproject = tomllib.loads(projects[0].read_text(encoding="utf-8"))
+    assert root_pyproject["dependency-groups"]["release"] == [
+        "build==1.5.1",
+        "hatchling==1.31.0",
+    ]
 
 
 def test_packaging_workflow_has_no_redundant_pip_install() -> None:
@@ -177,12 +262,15 @@ def test_coverage_workflow_runs_backend_helpers_before_upload() -> None:
     coverage_section = workflow_text.split("- name: Run tests with coverage", 1)[1]
     coverage_section = coverage_section.split("- name: Upload coverage reports", 1)[0]
 
-    assert "uv run pytest" in coverage_section
-    assert "uv run ./bin/pytest-pg --fast" in coverage_section
-    assert "uv run ./bin/pytest-redis --fast" in coverage_section
+    assert "uv run --frozen --no-sync pytest" in coverage_section
+    assert "uv run --frozen --no-sync ./bin/pytest-pg --fast" in coverage_section
+    assert "uv run --frozen --no-sync ./bin/pytest-redis --fast" in coverage_section
     assert coverage_section.count("--cov-append") == 3
-    assert "uv run python .github/scripts/combine_coverage.py" in coverage_section
-    assert "uv run coverage xml" in coverage_section
+    assert (
+        "uv run --frozen --no-sync python .github/scripts/combine_coverage.py"
+        in coverage_section
+    )
+    assert "uv run --frozen --no-sync coverage xml" in coverage_section
     assert coverage_section.index("./bin/pytest-pg --fast") < coverage_section.index(
         "combine_coverage.py"
     )

--- a/uv.lock
+++ b/uv.lock
@@ -206,6 +206,21 @@ wheels = [
 ]
 
 [[package]]
+name = "hatchling"
+version = "1.31.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "pluggy" },
+    { name = "trove-classifiers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/25/e2/dfa73fe78f773018dcaebc6d09b819bc10d328ff5a6b4a66efa1e3d71f52/hatchling-1.31.0.tar.gz", hash = "sha256:6b48ad4068a482ed7239b3a8215bc55b47aad3345d58dfc94e553c5d2d46211b", size = 57208, upload-time = "2026-07-08T01:48:32.237Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/e2/2c0af0a52d16be74a4f194564fcdc417521ed863e9b65e4bc9052dacba6f/hatchling-1.31.0-py3-none-any.whl", hash = "sha256:aac80bec8b6fe35e8480f1c335be8910fa210a0e6f735a139be205dadcacb544", size = 77747, upload-time = "2026-07-08T01:48:31.024Z" },
+]
+
+[[package]]
 name = "hypothesis"
 version = "6.156.5"
 source = { registry = "https://pypi.org/simple" }
@@ -661,6 +676,10 @@ redis = [
 fuzz = [
     { name = "atheris", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
+release = [
+    { name = "build" },
+    { name = "hatchling" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -684,6 +703,10 @@ provides-extras = ["dev", "pg", "redis"]
 
 [package.metadata.requires-dev]
 fuzz = [{ name = "atheris", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'", specifier = ">=2.3.0" }]
+release = [
+    { name = "build", specifier = "==1.5.1" },
+    { name = "hatchling", specifier = "==1.31.0" },
+]
 
 [[package]]
 name = "simplebroker-pg"
@@ -784,6 +807,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
     { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
     { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "trove-classifiers"
+version = "2026.6.1.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/e3/7ca82ee24c82d344584abd5b8637b3bd056f2900226e8d82fc22f1184b92/trove_classifiers-2026.6.1.19.tar.gz", hash = "sha256:c5132b4b61a829d11cfbd2d72e97f20a45ed6edb95e45c5efdeb5e00836b2745", size = 17059, upload-time = "2026-06-01T19:41:34.649Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/a4/81502f486f01db95bc8320646a8a12511f5e556cb63d5e224d91816605c4/trove_classifiers-2026.6.1.19-py3-none-any.whl", hash = "sha256:ab4c4ec93cc4a4e7815fa759906e05e6bb3f2fbd92ea0f897288c6a43efd15b3", size = 14211, upload-time = "2026-06-01T19:41:33.434Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Scope

Implements Tasks 1 and 2 from the release reproducibility plan:

- pins uv 0.11.28 across every uv workflow and enforces the local 0.11 compatibility range
- adds `bin/bump_uv.py` to update and check all workflow pins plus all three lockfiles atomically
- replaces live CI installs and editable overlays with frozen or locked root environments
- locks `build==1.5.1` and `hatchling==1.31.0`, disables build isolation, and removes release caches
- keeps the three existing trusted-publisher workflow identities unchanged

## Task 0 baseline

Starting main SHA: `7311c278fd4812ec389d9c49ac77271dec8245a7`.

- root lock: current
- Postgres lock: stale
- Redis lock: stale
- Actions policy: all actions allowed; SHA enforcement off
- immutable releases: off
- `pypi` environment: no deployment tag policy
- tag ruleset: none; only the existing default-branch destructive-update ruleset was present

Baseline runs:

- [CodeQL](https://github.com/VanL/simplebroker/actions/runs/29224027176)
- [Fuzz](https://github.com/VanL/simplebroker/actions/runs/29224061445)
- [Scorecard](https://github.com/VanL/simplebroker/actions/runs/29214861930)
- [Test](https://github.com/VanL/simplebroker/actions/runs/29214398160)
- [Postgres](https://github.com/VanL/simplebroker/actions/runs/29214398138)
- [Redis](https://github.com/VanL/simplebroker/actions/runs/29214398147)

## Local evidence

- `python bin/bump_uv.py --check`: all three locks current
- lock SHA-256 values remained byte-for-byte stable across the repeated check
- focused tests: 119 passed
- full core suite: 1,590 passed, 13 skipped
- PG helper: 850 passed, 2 skipped; extension 101 passed
- Redis helper: 843 passed, 9 skipped; extension 79 passed
- packaging smoke built and installed all three artifacts on Python 3.11
- locked frontend: build 1.5.1; hatchling 1.31.0
- ruff, formatting, mypy, YAML parsing, and diff checks pass

Manual PR-head fuzz runs will be linked before merge.
