### PR TITLE
Make SQLite bootstrap atomic

### DIFF
--- a/simplebroker/_backends/sqlite/schema.py
+++ b/simplebroker/_backends/sqlite/schema.py
@@ -35,43 +35,48 @@ def initialize_database(
     *,
     run_with_retry: Callable[[Callable[[], Any]], Any],
 ) -> None:
-    """Run the built-in SQLite schema/bootstrap setup."""
-    run_with_retry(lambda: runner.run(CREATE_MESSAGES_TABLE))
+    """Run the built-in SQLite schema/bootstrap setup atomically."""
+    run_with_retry(runner.begin_immediate)
+    try:
+        run_with_retry(lambda: runner.run(CREATE_MESSAGES_TABLE))
 
-    for drop_sql in DROP_OLD_INDEXES:
+        for drop_sql in DROP_OLD_INDEXES:
 
-        def drop_index(sql: str = drop_sql) -> Any:
-            return runner.run(sql)
+            def drop_index(sql: str = drop_sql) -> Any:
+                return runner.run(sql)
 
-        run_with_retry(drop_index)
+            run_with_retry(drop_index)
 
-    run_with_retry(lambda: runner.run(CREATE_QUEUE_TS_ID_INDEX))
+        run_with_retry(lambda: runner.run(CREATE_QUEUE_TS_ID_INDEX))
 
-    has_claimed_column = bool(
-        run_with_retry(lambda: messages_has_claimed_column(runner))
-    )
-    if has_claimed_column:
-        run_with_retry(lambda: runner.run(CREATE_UNCLAIMED_INDEX))
-        run_with_retry(lambda: runner.run(CREATE_PENDING_QUEUE_TS_INDEX))
-
-    run_with_retry(lambda: runner.run(CREATE_META_TABLE))
-    run_with_retry(lambda: runner.run(INIT_LAST_TS))
-    run_with_retry(lambda: runner.run(CREATE_ALIASES_TABLE))
-    run_with_retry(lambda: runner.run(CREATE_ALIAS_TARGET_INDEX))
-    run_with_retry(lambda: runner.run(INSERT_ALIAS_VERSION_META))
-    run_with_retry(
-        lambda: runner.run(
-            "INSERT OR IGNORE INTO meta (key, value) VALUES ('magic', ?)",
-            (SIMPLEBROKER_MAGIC,),
+        has_claimed_column = bool(
+            run_with_retry(lambda: messages_has_claimed_column(runner))
         )
-    )
-    run_with_retry(
-        lambda: runner.run(
-            "INSERT OR IGNORE INTO meta (key, value) VALUES ('schema_version', ?)",
-            (SCHEMA_VERSION,),
+        if has_claimed_column:
+            run_with_retry(lambda: runner.run(CREATE_UNCLAIMED_INDEX))
+            run_with_retry(lambda: runner.run(CREATE_PENDING_QUEUE_TS_INDEX))
+
+        run_with_retry(lambda: runner.run(CREATE_META_TABLE))
+        run_with_retry(lambda: runner.run(INIT_LAST_TS))
+        run_with_retry(lambda: runner.run(CREATE_ALIASES_TABLE))
+        run_with_retry(lambda: runner.run(CREATE_ALIAS_TARGET_INDEX))
+        run_with_retry(lambda: runner.run(INSERT_ALIAS_VERSION_META))
+        run_with_retry(
+            lambda: runner.run(
+                "INSERT OR IGNORE INTO meta (key, value) VALUES ('magic', ?)",
+                (SIMPLEBROKER_MAGIC,),
+            )
         )
-    )
-    run_with_retry(runner.commit)
+        run_with_retry(
+            lambda: runner.run(
+                "INSERT OR IGNORE INTO meta (key, value) VALUES ('schema_version', ?)",
+                (SCHEMA_VERSION,),
+            )
+        )
+        run_with_retry(runner.commit)
+    except BaseException:
+        runner.rollback()
+        raise
 
 
 def meta_table_exists(runner: SQLRunner) -> bool:

--- a/tests/test_runner_validation.py
+++ b/tests/test_runner_validation.py
@@ -1,5 +1,6 @@
 """Test SQLiteRunner database file validation during connection phase."""
 
+import sqlite3
 import tempfile
 from collections.abc import Iterable
 from pathlib import Path
@@ -13,6 +14,21 @@ from simplebroker._constants import SCHEMA_VERSION
 from simplebroker._exceptions import OperationalError
 from simplebroker._phaselock import PhaseLockService
 from simplebroker._runner import SetupPhase, SQLiteRunner
+from simplebroker.db import BrokerCore
+
+
+class _FailFirstCommitRunner(SQLiteRunner):
+    """Inject a failure at the schema bootstrap commit boundary."""
+
+    def __init__(self, db_path: str) -> None:
+        super().__init__(db_path)
+        self._fail_first_commit = True
+
+    def commit(self) -> None:
+        if self._fail_first_commit:
+            self._fail_first_commit = False
+            raise RuntimeError("injected bootstrap commit failure")
+        super().commit()
 
 
 def _force_status_sidecars(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -204,6 +220,42 @@ class TestSQLiteRunnerValidation:
         assert service.status_base_path == tmp_path / "broker.db.status"
         assert service.status_base_path.exists()
         assert _read_status_file(db_path) == list(_setup_phase_names())
+
+    @pytest.mark.sqlite_only
+    def test_failed_bootstrap_rolls_back_before_phaselock_marks_schema_complete(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _force_status_sidecars(monkeypatch)
+        db_path = tmp_path / "broker.db"
+        failing_runner = _FailFirstCommitRunner(str(db_path))
+
+        try:
+            with pytest.raises(RuntimeError, match="injected bootstrap commit failure"):
+                BrokerCore(failing_runner)
+
+            assert _read_status_file(db_path) == ["connection"]
+            with sqlite3.connect(db_path) as conn:
+                tables = conn.execute(
+                    "SELECT name FROM sqlite_master "
+                    "WHERE type = 'table' AND name NOT LIKE 'sqlite_%'"
+                ).fetchall()
+            assert tables == []
+        finally:
+            failing_runner.close()
+
+        retry_runner = SQLiteRunner(str(db_path))
+        try:
+            BrokerCore(retry_runner)
+            assert _read_status_file(db_path) == list(_setup_phase_names())
+            assert retry_runner.run(
+                "SELECT name FROM sqlite_master "
+                "WHERE type = 'table' AND name = 'messages'",
+                fetch=True,
+            ) == [("messages",)]
+        finally:
+            retry_runner.close()
 
     @pytest.mark.sqlite_only
     def test_connection_marker_check_does_not_open_sqlite_connection(

--- a/tests/test_sqlite_schema.py
+++ b/tests/test_sqlite_schema.py
@@ -82,6 +82,27 @@ def test_initialize_database_bootstraps_core_schema_and_metadata(
         runner.close()
 
 
+def test_initialize_database_uses_one_explicit_transaction(tmp_path: Path) -> None:
+    runner = _runner(tmp_path / "broker.db")
+    conn = runner.get_connection()
+    statements: list[str] = []
+    conn.set_trace_callback(statements.append)
+
+    try:
+        initialize_database(runner, run_with_retry=_run_direct)
+    finally:
+        conn.set_trace_callback(None)
+        runner.close()
+
+    transaction_statements = [
+        statement
+        for statement in statements
+        if statement.lstrip().split(None, maxsplit=1)[0].upper()
+        in {"BEGIN", "COMMIT", "ROLLBACK"}
+    ]
+    assert transaction_statements == ["BEGIN IMMEDIATE", "COMMIT"]
+
+
 def test_migrate_schema_applies_v2_v3_v4_and_v5_in_order(tmp_path: Path) -> None:
     db_path = tmp_path / "old.db"
     _create_v1_messages_table(db_path)


### PR DESCRIPTION
## Summary

- run SQLite schema bootstrap inside one explicit `BEGIN IMMEDIATE` transaction
- roll back the whole bootstrap when the final commit fails
- preserve phaselock ordering so the schema marker is written only after commit
- allow a fresh phaselock owner to retry a failed bootstrap cleanly

## Why

A Windows 3.14 CI host timed out three independent CLI processes during first-database setup. Each process was still moving through different schema statements on a separate database. A local SQL trace confirmed bootstrap issued 14 schema writes with no explicit transaction, so each write autocommitted. The unchanged failed job passed on rerun.

This change keeps the existing timeout and contention tests strict while reducing the durable bootstrap boundary from 14 writes to one transaction.

## Verification

- red tests first: missing transaction and partially visible schema after an injected commit failure
- `uv run pytest -q -n0 tests/test_sqlite_schema.py tests/test_runner_validation.py tests/test_sqlite_setup_contention.py tests/test_phaselock.py`
- `uv run --frozen --no-sync pytest -q`
- `uv run --frozen --no-sync mypy simplebroker --config-file pyproject.toml`
- full ruff check and format check for `simplebroker` and `tests`
