### PR TITLE
Harden release publication boundaries

### DIFF
--- a/.github/scripts/release_publication.py
+++ b/.github/scripts/release_publication.py
@@ -1,0 +1,425 @@
+#!/usr/bin/env python3
+"""Manage draft-first, immutable-compatible GitHub Release publication."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections.abc import Mapping, Sequence
+from typing import Final
+
+GITHUB_API_BASE: Final[str] = "https://api.github.com"
+GITHUB_API_VERSION: Final[str] = "2026-03-10"
+PYPI_API_BASE: Final[str] = "https://pypi.org/pypi"
+HTTP_TIMEOUT_SECONDS: Final[float] = 30.0
+PYPI_RETRY_DELAYS: Final[tuple[int, ...]] = (15, 30, 60, 120)
+
+
+def _mapping(value: object, *, label: str) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        raise RuntimeError(f"{label} was not a JSON object")
+    return value
+
+
+def github_api_request(
+    method: str,
+    path: str,
+    *,
+    token: str,
+    body: object = None,
+) -> object:
+    """Send one authenticated GitHub API request and decode its JSON response."""
+
+    if not path.startswith("/"):
+        raise RuntimeError("GitHub API path must start with /")
+    data = None if body is None else json.dumps(body).encode("utf-8")
+    request = urllib.request.Request(
+        f"{GITHUB_API_BASE}{path}",
+        data=data,
+        method=method,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "User-Agent": "simplebroker-release-publication",
+            "X-GitHub-Api-Version": GITHUB_API_VERSION,
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=HTTP_TIMEOUT_SECONDS) as response:
+            raw = response.read()
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(
+            f"GitHub API {method} {path} failed: HTTP {exc.code}: {detail}"
+        ) from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"GitHub API {method} {path} failed: {exc.reason}") from exc
+
+    if not raw:
+        return None
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"GitHub API {method} {path} returned invalid JSON") from exc
+
+
+def list_releases(repo: str, token: str) -> tuple[Mapping[str, object], ...]:
+    """List releases, including drafts visible to the authenticated maintainer."""
+
+    releases: list[Mapping[str, object]] = []
+    page = 1
+    encoded_repo = urllib.parse.quote(repo, safe="/")
+    while True:
+        path = f"/repos/{encoded_repo}/releases?per_page=100&page={page}"
+        payload = github_api_request("GET", path, token=token)
+        if not isinstance(payload, list):
+            raise RuntimeError("GitHub releases response was not a JSON list")
+        page_releases = [
+            _mapping(release, label="GitHub release") for release in payload
+        ]
+        releases.extend(page_releases)
+        if len(payload) < 100:
+            return tuple(releases)
+        page += 1
+
+
+def matching_releases(
+    releases: Sequence[Mapping[str, object]],
+    tag: str,
+) -> tuple[Mapping[str, object], ...]:
+    """Return releases whose tag_name exactly matches ``tag``."""
+
+    return tuple(release for release in releases if release.get("tag_name") == tag)
+
+
+def resolve_tag_commit(repo: str, tag: str, token: str) -> str:
+    """Resolve a remote lightweight or annotated tag to its commit SHA."""
+
+    encoded_repo = urllib.parse.quote(repo, safe="/")
+    encoded_tag = urllib.parse.quote(tag, safe="")
+    payload = github_api_request(
+        "GET",
+        f"/repos/{encoded_repo}/git/ref/tags/{encoded_tag}",
+        token=token,
+    )
+    current = _mapping(payload, label="Git tag reference").get("object")
+
+    for _ in range(8):
+        tag_object = _mapping(current, label="Git tag object")
+        object_type = tag_object.get("type")
+        sha = tag_object.get("sha")
+        if not isinstance(sha, str) or not sha:
+            raise RuntimeError(f"Git tag {tag} did not contain an object SHA")
+        if object_type == "commit":
+            return sha
+        if object_type != "tag":
+            raise RuntimeError(
+                f"Git tag {tag} resolved to unsupported object type {object_type!r}"
+            )
+        annotated = github_api_request(
+            "GET",
+            f"/repos/{encoded_repo}/git/tags/{sha}",
+            token=token,
+        )
+        current = _mapping(annotated, label="Annotated Git tag").get("object")
+
+    raise RuntimeError(f"Git tag {tag} exceeded the annotated-tag resolution limit")
+
+
+def _require_expected_tag_sha(
+    *,
+    repo: str,
+    tag: str,
+    expected_sha: str,
+    token: str,
+) -> None:
+    actual_sha = resolve_tag_commit(repo, tag, token)
+    if actual_sha != expected_sha:
+        raise RuntimeError(
+            f"Remote tag {tag} at {actual_sha} does not match expected release SHA "
+            f"{expected_sha}"
+        )
+
+
+def _release_id(release: Mapping[str, object]) -> int:
+    release_id = release.get("id")
+    if not isinstance(release_id, int) or isinstance(release_id, bool):
+        raise RuntimeError("GitHub Release did not contain a numeric id")
+    return release_id
+
+
+def require_exact_assets(
+    release: Mapping[str, object],
+    expected_assets: Sequence[str],
+) -> None:
+    """Require exactly one uploaded release asset for every expected name."""
+
+    expected = tuple(expected_assets)
+    wheel_count = sum(name.endswith(".whl") for name in expected)
+    sdist_count = sum(name.endswith(".tar.gz") for name in expected)
+    sigstore_count = sum(name.endswith(".sigstore.json") for name in expected)
+    if (wheel_count, sdist_count, sigstore_count) != (1, 1, 1):
+        raise RuntimeError(
+            "Expected release assets must contain one wheel, one sdist, and one "
+            "Sigstore bundle; "
+            f"observed wheel={wheel_count}, sdist={sdist_count}, "
+            f"sigstore={sigstore_count}"
+        )
+
+    raw_assets = release.get("assets")
+    if not isinstance(raw_assets, list):
+        raise RuntimeError("GitHub Release asset set was not a JSON list")
+
+    names: list[str] = []
+    incomplete: list[str] = []
+    for raw_asset in raw_assets:
+        asset = _mapping(raw_asset, label="GitHub Release asset")
+        name = asset.get("name")
+        if not isinstance(name, str) or not name:
+            raise RuntimeError("GitHub Release asset set contained an unnamed asset")
+        names.append(name)
+        if asset.get("state") != "uploaded":
+            incomplete.append(name)
+
+    if len(set(expected)) != len(expected):
+        raise RuntimeError("Expected release asset set contains duplicate names")
+    if len(set(names)) != len(names):
+        raise RuntimeError("GitHub Release asset set contains duplicate names")
+    if set(names) != set(expected) or incomplete:
+        missing = sorted(set(expected) - set(names))
+        extra = sorted(set(names) - set(expected))
+        raise RuntimeError(
+            "GitHub Release asset set does not match expected assets; "
+            f"missing={missing}, extra={extra}, incomplete={sorted(incomplete)}"
+        )
+
+
+def _one_matching_release(
+    *,
+    repo: str,
+    tag: str,
+    token: str,
+) -> Mapping[str, object]:
+    matches = matching_releases(list_releases(repo, token), tag)
+    if len(matches) != 1:
+        raise RuntimeError(
+            f"Expected exactly one GitHub Release for tag {tag}, found {len(matches)}"
+        )
+    return matches[0]
+
+
+def replace_draft(
+    *,
+    repo: str,
+    tag: str,
+    expected_sha: str,
+    token: str,
+) -> None:
+    """Delete a stale matching draft after independently verifying the tag SHA."""
+
+    _require_expected_tag_sha(
+        repo=repo,
+        tag=tag,
+        expected_sha=expected_sha,
+        token=token,
+    )
+    matches = matching_releases(list_releases(repo, token), tag)
+    if not matches:
+        print(f"No existing draft for {tag}; staging a new draft")
+        return
+    if len(matches) != 1:
+        raise RuntimeError(
+            f"Expected at most one GitHub Release for tag {tag}, found {len(matches)}"
+        )
+
+    release = matches[0]
+    if release.get("draft") is not True:
+        raise RuntimeError(
+            f"Refusing to delete published release for tag {tag}; published releases "
+            "are permanent"
+        )
+    release_id = _release_id(release)
+    encoded_repo = urllib.parse.quote(repo, safe="/")
+    github_api_request(
+        "DELETE",
+        f"/repos/{encoded_repo}/releases/{release_id}",
+        token=token,
+    )
+    print(f"Deleted stale draft release for {tag}")
+
+
+def _normalize_package_name(name: str) -> str:
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def pypi_release_state(package: str, version: str) -> tuple[bool, str]:
+    """Return whether PyPI has the exact package/version and a status description."""
+
+    encoded_package = urllib.parse.quote(package, safe="")
+    encoded_version = urllib.parse.quote(version, safe="")
+    url = f"{PYPI_API_BASE}/{encoded_package}/{encoded_version}/json"
+    request = urllib.request.Request(
+        url,
+        headers={"Accept": "application/json", "User-Agent": "simplebroker-release"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=HTTP_TIMEOUT_SECONDS) as response:
+            payload = json.load(response)
+    except urllib.error.HTTPError as exc:
+        return False, f"HTTP {exc.code} from {url}"
+    except urllib.error.URLError as exc:
+        return False, f"network error from {url}: {exc.reason}"
+    except json.JSONDecodeError:
+        return False, f"invalid JSON from {url}"
+
+    if not isinstance(payload, Mapping):
+        return False, f"non-object JSON from {url}"
+    info = payload.get("info")
+    if not isinstance(info, Mapping):
+        return False, f"missing project info from {url}"
+    observed_name = info.get("name")
+    observed_version = info.get("version")
+    if not isinstance(observed_name, str) or not isinstance(observed_version, str):
+        return False, f"incomplete project info from {url}"
+    if _normalize_package_name(observed_name) != _normalize_package_name(package):
+        return False, f"observed package {observed_name} instead of {package}"
+    if observed_version != version:
+        return False, f"observed version {observed_version} instead of {version}"
+    return True, f"{observed_name} {observed_version}"
+
+
+def wait_for_pypi(package: str, version: str) -> None:
+    """Wait a bounded few minutes for an already-published rerun to reach PyPI."""
+
+    last_state = "not checked"
+    for delay in PYPI_RETRY_DELAYS:
+        exists, last_state = pypi_release_state(package, version)
+        if exists:
+            return
+        time.sleep(delay)
+
+    exists, last_state = pypi_release_state(package, version)
+    if exists:
+        return
+    raise RuntimeError(
+        f"PyPI did not report {package} {version} after five attempts; "
+        f"last observed state: {last_state}"
+    )
+
+
+def publish_draft(
+    *,
+    repo: str,
+    tag: str,
+    expected_sha: str,
+    package: str,
+    version: str,
+    expected_assets: Sequence[str],
+    token: str,
+) -> None:
+    """Verify and publish the exact matching draft, or validate an exact rerun."""
+
+    _require_expected_tag_sha(
+        repo=repo,
+        tag=tag,
+        expected_sha=expected_sha,
+        token=token,
+    )
+    release = _one_matching_release(repo=repo, tag=tag, token=token)
+    require_exact_assets(release, expected_assets)
+
+    if release.get("draft") is False:
+        if release.get("immutable") is not True:
+            raise RuntimeError(
+                f"Published release for tag {tag} is not immutable; refusing to "
+                "treat it as exact rerun success"
+            )
+        wait_for_pypi(package, version)
+        print(f"Immutable release {tag} and PyPI {package} {version} already match")
+        return
+    if release.get("draft") is not True:
+        raise RuntimeError(f"GitHub Release for tag {tag} has invalid draft state")
+
+    release_id = _release_id(release)
+    encoded_repo = urllib.parse.quote(repo, safe="/")
+    updated = github_api_request(
+        "PATCH",
+        f"/repos/{encoded_repo}/releases/{release_id}",
+        token=token,
+        body={"draft": False},
+    )
+    updated_release = _mapping(updated, label="Published GitHub Release")
+    if updated_release.get("draft") is not False:
+        raise RuntimeError(f"GitHub Release for tag {tag} remained a draft")
+    if updated_release.get("immutable") is not True:
+        raise RuntimeError(f"Published GitHub Release for tag {tag} is not immutable")
+    print(f"Published immutable GitHub Release {tag}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Manage draft-first GitHub Release publication state"
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    replace_parser = subparsers.add_parser("replace-draft")
+    replace_parser.add_argument("--repo", required=True)
+    replace_parser.add_argument("--tag", required=True)
+    replace_parser.add_argument("--expected-sha", required=True)
+
+    publish_parser = subparsers.add_parser("publish-draft")
+    publish_parser.add_argument("--repo", required=True)
+    publish_parser.add_argument("--tag", required=True)
+    publish_parser.add_argument("--expected-sha", required=True)
+    publish_parser.add_argument("--package", required=True)
+    publish_parser.add_argument("--version", required=True)
+    publish_parser.add_argument(
+        "--expected-asset",
+        action="append",
+        dest="expected_assets",
+        required=True,
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    token = os.environ.get("GITHUB_TOKEN", "").strip()
+    if not token:
+        parser.error("GITHUB_TOKEN is required")
+
+    try:
+        if args.command == "replace-draft":
+            replace_draft(
+                repo=args.repo,
+                tag=args.tag,
+                expected_sha=args.expected_sha,
+                token=token,
+            )
+        else:
+            publish_draft(
+                repo=args.repo,
+                tag=args.tag,
+                expected_sha=args.expected_sha,
+                package=args.package,
+                version=args.version,
+                expected_assets=tuple(args.expected_assets),
+                token=token,
+            )
+    except RuntimeError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/release-gate-pg.yml
+++ b/.github/workflows/release-gate-pg.yml
@@ -31,7 +31,9 @@ jobs:
 
       - name: Compute GitHub release name
         id: release
-        run: echo "name=simplebroker-pg ${{ steps.version.outputs.version }}" >> "$GITHUB_OUTPUT"
+        env:
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
+        run: printf 'name=%s %s\n' 'simplebroker-pg' "${RELEASE_VERSION}" >> "$GITHUB_OUTPUT"
 
   require-tests:
     runs-on: ubuntu-latest
@@ -161,10 +163,61 @@ jobs:
           name: ${{ env.PACKAGE_NAME }}-attestations
           path: attestations/*.sigstore.json
 
+  stage-github-release:
+    name: Stage draft GitHub Release
+    needs:
+      - extract-version
+      - build
+    runs-on: ubuntu-latest
+    timeout-minutes: 50
+    permissions:
+      actions: read
+      contents: write
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Download all the dists
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ env.PACKAGE_NAME }}-python-package-distributions
+          path: dist/
+
+      - name: Download attestation bundle
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ env.PACKAGE_NAME }}-attestations
+          path: attestations/
+
+      - name: Remove stale matching draft
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          python .github/scripts/release_publication.py replace-draft \
+            --repo "${GITHUB_REPOSITORY}" \
+            --tag "${GITHUB_REF_NAME}" \
+            --expected-sha "${GITHUB_SHA}"
+
+      - name: Stage complete draft release
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
+        with:
+          draft: true
+          fail_on_unmatched_files: true
+          name: ${{ needs.extract-version.outputs.release_name }}
+          generate_release_notes: true
+          tag_name: ${{ github.ref_name }}
+          target_commitish: ${{ github.sha }}
+          files: |
+            dist/*.tar.gz
+            dist/*.whl
+            attestations/*.sigstore.json
+
   publish-to-pypi:
     name: Publish to PyPI
     needs:
-      - build
+      - stage-github-release
     runs-on: ubuntu-latest
     timeout-minutes: 50
     environment:
@@ -183,10 +236,11 @@ jobs:
       - name: Publish distribution to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
 
-  github-release:
-    name: Upload to GitHub Release
+  publish-github-release:
+    name: Publish immutable GitHub Release
     needs:
       - extract-version
+      - stage-github-release
       - publish-to-pypi
     runs-on: ubuntu-latest
     timeout-minutes: 50
@@ -195,6 +249,10 @@ jobs:
       contents: write
 
     steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.sha }}
+
       - name: Download all the dists
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -207,13 +265,20 @@ jobs:
           name: ${{ env.PACKAGE_NAME }}-attestations
           path: attestations/
 
-      - name: Create GitHub Release and upload artifacts
-        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
-        with:
-          name: ${{ needs.extract-version.outputs.release_name }}
-          generate_release_notes: true
-          tag_name: ${{ github.ref_name }}
-          files: |
-            dist/*.tar.gz
-            dist/*.whl
-            attestations/*.sigstore.json
+      - name: Verify assets and publish draft
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          mapfile -t asset_paths < <(find dist attestations -type f -print | sort)
+          asset_args=()
+          for path in "${asset_paths[@]}"; do
+            asset_args+=(--expected-asset "${path##*/}")
+          done
+          python .github/scripts/release_publication.py publish-draft \
+            --repo "${GITHUB_REPOSITORY}" \
+            --tag "${GITHUB_REF_NAME}" \
+            --expected-sha "${GITHUB_SHA}" \
+            --package "${PACKAGE_NAME}" \
+            --version "${GITHUB_REF_NAME#simplebroker_pg/v}" \
+            "${asset_args[@]}"

--- a/.github/workflows/release-gate-redis.yml
+++ b/.github/workflows/release-gate-redis.yml
@@ -31,7 +31,9 @@ jobs:
 
       - name: Compute GitHub release name
         id: release
-        run: echo "name=simplebroker-redis ${{ steps.version.outputs.version }}" >> "$GITHUB_OUTPUT"
+        env:
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
+        run: printf 'name=%s %s\n' 'simplebroker-redis' "${RELEASE_VERSION}" >> "$GITHUB_OUTPUT"
 
   require-tests:
     runs-on: ubuntu-latest
@@ -161,10 +163,61 @@ jobs:
           name: ${{ env.PACKAGE_NAME }}-attestations
           path: attestations/*.sigstore.json
 
+  stage-github-release:
+    name: Stage draft GitHub Release
+    needs:
+      - extract-version
+      - build
+    runs-on: ubuntu-latest
+    timeout-minutes: 50
+    permissions:
+      actions: read
+      contents: write
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Download all the dists
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ env.PACKAGE_NAME }}-python-package-distributions
+          path: dist/
+
+      - name: Download attestation bundle
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ env.PACKAGE_NAME }}-attestations
+          path: attestations/
+
+      - name: Remove stale matching draft
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          python .github/scripts/release_publication.py replace-draft \
+            --repo "${GITHUB_REPOSITORY}" \
+            --tag "${GITHUB_REF_NAME}" \
+            --expected-sha "${GITHUB_SHA}"
+
+      - name: Stage complete draft release
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
+        with:
+          draft: true
+          fail_on_unmatched_files: true
+          name: ${{ needs.extract-version.outputs.release_name }}
+          generate_release_notes: true
+          tag_name: ${{ github.ref_name }}
+          target_commitish: ${{ github.sha }}
+          files: |
+            dist/*.tar.gz
+            dist/*.whl
+            attestations/*.sigstore.json
+
   publish-to-pypi:
     name: Publish to PyPI
     needs:
-      - build
+      - stage-github-release
     runs-on: ubuntu-latest
     timeout-minutes: 50
     environment:
@@ -183,10 +236,11 @@ jobs:
       - name: Publish distribution to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
 
-  github-release:
-    name: Upload to GitHub Release
+  publish-github-release:
+    name: Publish immutable GitHub Release
     needs:
       - extract-version
+      - stage-github-release
       - publish-to-pypi
     runs-on: ubuntu-latest
     timeout-minutes: 50
@@ -195,6 +249,10 @@ jobs:
       contents: write
 
     steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.sha }}
+
       - name: Download all the dists
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -207,13 +265,20 @@ jobs:
           name: ${{ env.PACKAGE_NAME }}-attestations
           path: attestations/
 
-      - name: Create GitHub Release and upload artifacts
-        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
-        with:
-          name: ${{ needs.extract-version.outputs.release_name }}
-          generate_release_notes: true
-          tag_name: ${{ github.ref_name }}
-          files: |
-            dist/*.tar.gz
-            dist/*.whl
-            attestations/*.sigstore.json
+      - name: Verify assets and publish draft
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          mapfile -t asset_paths < <(find dist attestations -type f -print | sort)
+          asset_args=()
+          for path in "${asset_paths[@]}"; do
+            asset_args+=(--expected-asset "${path##*/}")
+          done
+          python .github/scripts/release_publication.py publish-draft \
+            --repo "${GITHUB_REPOSITORY}" \
+            --tag "${GITHUB_REF_NAME}" \
+            --expected-sha "${GITHUB_SHA}" \
+            --package "${PACKAGE_NAME}" \
+            --version "${GITHUB_REF_NAME#simplebroker_redis/v}" \
+            "${asset_args[@]}"

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -146,10 +146,59 @@ jobs:
           name: ${{ env.PACKAGE_NAME }}-attestations
           path: attestations/*.sigstore.json
 
+  stage-github-release:
+    name: Stage draft GitHub Release
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    timeout-minutes: 50
+    permissions:
+      actions: read
+      contents: write
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Download all the dists
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ env.PACKAGE_NAME }}-python-package-distributions
+          path: dist/
+
+      - name: Download attestation bundle
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ env.PACKAGE_NAME }}-attestations
+          path: attestations/
+
+      - name: Remove stale matching draft
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          python .github/scripts/release_publication.py replace-draft \
+            --repo "${GITHUB_REPOSITORY}" \
+            --tag "${GITHUB_REF_NAME}" \
+            --expected-sha "${GITHUB_SHA}"
+
+      - name: Stage complete draft release
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
+        with:
+          draft: true
+          fail_on_unmatched_files: true
+          generate_release_notes: true
+          tag_name: ${{ github.ref_name }}
+          target_commitish: ${{ github.sha }}
+          files: |
+            dist/*.tar.gz
+            dist/*.whl
+            attestations/*.sigstore.json
+
   publish-to-pypi:
     name: Publish to PyPI
     needs:
-      - build
+      - stage-github-release
     runs-on: ubuntu-latest
     timeout-minutes: 50
     environment:
@@ -168,9 +217,10 @@ jobs:
       - name: Publish distribution to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
 
-  github-release:
-    name: Upload to GitHub Release
+  publish-github-release:
+    name: Publish immutable GitHub Release
     needs:
+      - stage-github-release
       - publish-to-pypi
     runs-on: ubuntu-latest
     timeout-minutes: 50
@@ -179,6 +229,10 @@ jobs:
       contents: write
 
     steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.sha }}
+
       - name: Download all the dists
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -191,12 +245,20 @@ jobs:
           name: ${{ env.PACKAGE_NAME }}-attestations
           path: attestations/
 
-      - name: Create GitHub Release and upload artifacts
-        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
-        with:
-          generate_release_notes: true
-          tag_name: ${{ github.ref_name }}
-          files: |
-            dist/*.tar.gz
-            dist/*.whl
-            attestations/*.sigstore.json
+      - name: Verify assets and publish draft
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          mapfile -t asset_paths < <(find dist attestations -type f -print | sort)
+          asset_args=()
+          for path in "${asset_paths[@]}"; do
+            asset_args+=(--expected-asset "${path##*/}")
+          done
+          python .github/scripts/release_publication.py publish-draft \
+            --repo "${GITHUB_REPOSITORY}" \
+            --tag "${GITHUB_REF_NAME}" \
+            --expected-sha "${GITHUB_SHA}" \
+            --package "${PACKAGE_NAME}" \
+            --version "${GITHUB_REF_NAME#v}" \
+            "${asset_args[@]}"

--- a/README.md
+++ b/README.md
@@ -2249,16 +2249,30 @@ python bin/release.py all
 
 # Preview the checks, version files, commit, and tag action
 python bin/release.py --dry-run
+
+# Read back the release-related GitHub settings without changing anything
+uv run python bin/release.py --check-repository-settings
 ```
 
-The helper checks the target version against GitHub Releases and PyPI, runs the
-release checks, updates version files when needed, commits release-file changes,
-pushes the branch, and then pushes the release tag. The tag workflow waits for
-the relevant normal test workflows on the same commit to finish green, then
-builds the distributions, publishes them to PyPI with trusted publishing, and
-creates the GitHub Release from the same top-level gate workflow. Keeping the
-build, attestation, and publish steps in the gate workflow makes PyPI's trusted
-publisher identity match the artifact attestation build-config URI.
+Real releases must run from `main`. The helper checks the target version against
+GitHub Releases and PyPI, verifies the repository's immutable-release, tag,
+environment, and Actions SHA-pinning settings, runs the local release checks,
+updates and commits release files, and pushes the release commit to `main`. It
+then waits for the target's normal workflows to pass on that exact commit and
+checks that the commit is still reachable from a freshly fetched `origin/main`.
+Only then does it create the final tag at the tested SHA and push it.
+
+Remote release tags are permanent. They are never moved or deleted. A wrong
+remote tag requires a new version. A local-only tag may be replaced before it
+is pushed.
+
+The tag workflow rechecks the normal workflows and tag SHA, builds and attests
+the distributions, and stages every distribution and Sigstore bundle on a
+draft GitHub Release. It publishes to PyPI with trusted publishing only after
+that complete draft exists, then verifies the exact draft asset set and
+publishes the immutable GitHub Release. Keeping the build, attestation, and
+publish steps in the top-level gate workflow makes PyPI's trusted-publisher
+identity match the artifact attestation build-config URI.
 The local release helper also ruff-checks `examples/`, runs all
 pytest-discovered example tests under `examples/`, mypy-checks every Python
 example file, and mypy-checks the selected extension test tree. Core and batch
@@ -2267,6 +2281,14 @@ are not part of the CI release workflows.
 Core releases wait for `Test`, `Test Postgres Extension`, and
 `Test Redis Extension`; extension releases wait for `Test` plus their matching
 backend workflow.
+
+If pre-tag CI fails, is cancelled, is missing, or times out, no final tag has
+been created. Fix `main` and rerun the helper with the same unpublished
+version. An interrupted helper can also be rerun at the same release commit;
+it resumes the exact-SHA check without creating another release commit. If a
+transient publication step fails after the tag exists, retry the workflow only
+when the tag still points at the same SHA. If recovery needs a code change, use
+the next patch version. Never delete, move, or reuse a published tag or version.
 
 PyPI trusted publisher entries should use repository `VanL/simplebroker`, the
 `pypi` environment, and these GitHub Actions workflows:

--- a/bin/release.py
+++ b/bin/release.py
@@ -1065,19 +1065,33 @@ def _merge_command_env(
     return merged
 
 
+def _merge_public_and_private_command_env(
+    env_overrides: dict[str, str] | None,
+    private_env_overrides: dict[str, str] | None,
+) -> dict[str, str] | None:
+    """Merge logged and private command environment without logging private values."""
+
+    merged = _merge_command_env(env_overrides)
+    if not private_env_overrides:
+        return merged
+    return _merge_command_env(private_env_overrides, base_env=merged)
+
+
 def _format_command_prefix(
     env_overrides: dict[str, str] | None,
     *,
-    sensitive_env_keys: frozenset[str] = frozenset(),
+    private_env_keys: frozenset[str] = frozenset(),
 ) -> str:
     """Format environment overrides shown before a command in logs."""
 
-    if not env_overrides:
+    if not env_overrides and not private_env_keys:
         return ""
-    return " ".join(
-        f"{key}=" + ("<redacted>" if key in sensitive_env_keys else shlex.quote(value))
-        for key, value in sorted(env_overrides.items())
-    )
+    public_parts = [
+        f"{key}={shlex.quote(value)}"
+        for key, value in sorted((env_overrides or {}).items())
+    ]
+    private_parts = [f"{key}=<redacted>" for key in sorted(private_env_keys)]
+    return " ".join((*public_parts, *private_parts))
 
 
 def _format_cwd_suffix(cwd: Path) -> str:
@@ -1092,13 +1106,19 @@ def run_command(
     cwd: Path = PROJECT_ROOT,
     dry_run: bool = False,
     env_overrides: dict[str, str] | None = None,
-    sensitive_env_keys: frozenset[str] = frozenset(),
+    private_env_overrides: dict[str, str] | None = None,
 ) -> None:
     """Run a command, printing it first."""
 
+    overlapping_keys = set(env_overrides or ()) & set(private_env_overrides or ())
+    if overlapping_keys:
+        raise RuntimeError(
+            "Command environment keys cannot be both public and private: "
+            + ", ".join(sorted(overlapping_keys))
+        )
     prefix = _format_command_prefix(
         env_overrides,
-        sensitive_env_keys=sensitive_env_keys,
+        private_env_keys=frozenset(private_env_overrides or ()),
     )
     formatted = _format_command(command)
     command_text = f"$ {prefix} {formatted}" if prefix else f"$ {formatted}"
@@ -1109,7 +1129,10 @@ def run_command(
         command,
         cwd=cwd,
         check=True,
-        env=_merge_command_env(env_overrides),
+        env=_merge_public_and_private_command_env(
+            env_overrides,
+            private_env_overrides,
+        ),
     )
 
 
@@ -1891,8 +1914,7 @@ def wait_for_release_workflows(
     run_command(
         tuple(command),
         dry_run=dry_run,
-        env_overrides={"GITHUB_TOKEN": token},
-        sensitive_env_keys=frozenset({"GITHUB_TOKEN"}),
+        private_env_overrides={"GITHUB_TOKEN": token},
     )
 
 

--- a/bin/release.py
+++ b/bin/release.py
@@ -4,12 +4,14 @@
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import re
 import shlex
 import shutil
 import subprocess
 import sys
+from collections.abc import Mapping
 from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
@@ -17,6 +19,14 @@ from typing import Final, Literal
 from urllib import error as urllib_error
 from urllib import parse as urllib_parse
 from urllib import request as urllib_request
+
+
+def _local_pytest_worker_count(logical_cpu_count: int | None = None) -> int:
+    """Return the local release-gate worker count: logical CPUs plus one."""
+
+    detected = os.cpu_count() if logical_cpu_count is None else logical_cpu_count
+    return max(detected or 1, 1) + 1
+
 
 PROJECT_ROOT: Final[Path] = Path(__file__).resolve().parents[1]
 PYPROJECT_PATH: Final[Path] = PROJECT_ROOT / "pyproject.toml"
@@ -42,8 +52,10 @@ ROOT_RELEASE_WORKFLOW: Final[str] = ".github/workflows/release-gate.yml"
 PG_RELEASE_WORKFLOW: Final[str] = ".github/workflows/release-gate-pg.yml"
 REDIS_RELEASE_WORKFLOW: Final[str] = ".github/workflows/release-gate-redis.yml"
 GITHUB_API_BASE: Final[str] = "https://api.github.com"
+GITHUB_API_VERSION: Final[str] = "2026-03-10"
 PYPI_API_BASE: Final[str] = "https://pypi.org/pypi"
 HTTP_TIMEOUT_SECONDS: Final[float] = 10.0
+LOCAL_PYTEST_WORKERS: Final[int] = _local_pytest_worker_count()
 VERSION_PATTERN: Final[re.Pattern[str]] = re.compile(r"^\d+\.\d+\.\d+$")
 PYPROJECT_VERSION_PATTERN: Final[re.Pattern[str]] = re.compile(
     r'(?m)^version = "([^"]+)"$'
@@ -69,6 +81,21 @@ REDIS_EXTRA_DEPENDENCY_PATTERN: Final[re.Pattern[str]] = re.compile(
 )
 PENDING_RELEASE_COMMIT: Final[str] = "<release-commit>"
 ALL_RELEASE_TARGET_KEY: Final[str] = "all"
+RELEASE_TAG_RULESET_NAME: Final[str] = "Protect release tags"
+RELEASE_TAG_PATTERNS: Final[frozenset[str]] = frozenset(
+    {
+        "refs/tags/v*",
+        "refs/tags/simplebroker_pg/v*",
+        "refs/tags/simplebroker_redis/v*",
+    }
+)
+PYPI_ENVIRONMENT_TAG_PATTERNS: Final[frozenset[tuple[str, str]]] = frozenset(
+    {
+        ("tag", "v*"),
+        ("tag", "simplebroker_pg/v*"),
+        ("tag", "simplebroker_redis/v*"),
+    }
+)
 # Minimum simplebroker release allowed for each backend API version.
 BACKEND_API_MIN_CORE_VERSION: Final[dict[int, str]] = {
     1: "5.0.0",
@@ -88,7 +115,8 @@ ROOT_TEST_PYTEST_ARGS: Final[tuple[str, ...]] = (
     "--tb=short",
     "-m",
     "",
-    "--override-ini=addopts=-ra -q --strict-markers -n auto --dist loadgroup",
+    "--override-ini=addopts=-ra -q --strict-markers "
+    f"-n {LOCAL_PYTEST_WORKERS} --dist loadgroup",
 )
 PG_TEST_COMMAND: Final[tuple[str, ...]] = (
     "uv",
@@ -110,7 +138,8 @@ EXAMPLE_TEST_COMMAND: Final[tuple[str, ...]] = (
     "--extra",
     "dev",
     "pytest",
-    "-n0",
+    "-n",
+    str(LOCAL_PYTEST_WORKERS),
     "examples",
 )
 SHELLCHECK_EXAMPLES_COMMAND: Final[tuple[str, ...]] = (
@@ -219,7 +248,6 @@ TagAction = Literal[
     "create",
     "push_local",
     "replace_local",
-    "replace_remote",
     "reuse_remote",
 ]
 
@@ -320,6 +348,15 @@ BATCH_RELEASE_TARGETS: Final[tuple[ReleaseTarget, ...]] = (
     REDIS_RELEASE_TARGET,
     ROOT_RELEASE_TARGET,
 )
+REQUIRED_WORKFLOWS_BY_TARGET: Final[dict[str, tuple[str, ...]]] = {
+    ROOT_RELEASE_TARGET.key: (
+        "Test",
+        "Test Postgres Extension",
+        "Test Redis Extension",
+    ),
+    PG_RELEASE_TARGET.key: ("Test", "Test Postgres Extension"),
+    REDIS_RELEASE_TARGET.key: ("Test", "Test Redis Extension"),
+}
 
 
 def validate_version(version: str) -> str:
@@ -1028,13 +1065,18 @@ def _merge_command_env(
     return merged
 
 
-def _format_command_prefix(env_overrides: dict[str, str] | None) -> str:
+def _format_command_prefix(
+    env_overrides: dict[str, str] | None,
+    *,
+    sensitive_env_keys: frozenset[str] = frozenset(),
+) -> str:
     """Format environment overrides shown before a command in logs."""
 
     if not env_overrides:
         return ""
     return " ".join(
-        f"{key}={shlex.quote(value)}" for key, value in sorted(env_overrides.items())
+        f"{key}=" + ("<redacted>" if key in sensitive_env_keys else shlex.quote(value))
+        for key, value in sorted(env_overrides.items())
     )
 
 
@@ -1050,10 +1092,14 @@ def run_command(
     cwd: Path = PROJECT_ROOT,
     dry_run: bool = False,
     env_overrides: dict[str, str] | None = None,
+    sensitive_env_keys: frozenset[str] = frozenset(),
 ) -> None:
     """Run a command, printing it first."""
 
-    prefix = _format_command_prefix(env_overrides)
+    prefix = _format_command_prefix(
+        env_overrides,
+        sensitive_env_keys=sensitive_env_keys,
+    )
     formatted = _format_command(command)
     command_text = f"$ {prefix} {formatted}" if prefix else f"$ {formatted}"
     print(f"{command_text}{_format_cwd_suffix(cwd)}")
@@ -1117,6 +1163,28 @@ def current_head_commit() -> str:
     """Return the current HEAD commit SHA."""
 
     return _git_output(("git", "rev-parse", "HEAD"), label="current HEAD commit")
+
+
+def current_branch() -> str:
+    """Return the current branch name, rejecting detached HEAD."""
+
+    branch = _git_output(
+        ("git", "branch", "--show-current"),
+        label="current branch",
+    )
+    if not branch:
+        raise RuntimeError("A real release cannot run from detached HEAD")
+    return branch
+
+
+def require_main_branch() -> None:
+    """Require real releases to run from the main branch."""
+
+    branch = current_branch()
+    if branch != "main":
+        raise RuntimeError(
+            f"A real release must run from main; current branch is {branch}"
+        )
 
 
 def local_tag_commit(tag_name: str) -> str | None:
@@ -1223,6 +1291,231 @@ def _github_api_auth_headers() -> dict[str, str]:
     return {"Authorization": f"Bearer {token}"}
 
 
+def _github_api_json(path: str, token: str) -> object:
+    """Return one authenticated GitHub API JSON response."""
+
+    if not path.startswith("/"):
+        raise RuntimeError("GitHub API path must start with /")
+    request = urllib_request.Request(
+        f"{GITHUB_API_BASE}{path}",
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "User-Agent": "simplebroker-release-helper",
+            "X-GitHub-Api-Version": GITHUB_API_VERSION,
+        },
+    )
+    try:
+        with urllib_request.urlopen(request, timeout=HTTP_TIMEOUT_SECONDS) as response:
+            return json.load(response)
+    except urllib_error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(
+            f"GitHub API request failed for {path}: HTTP {exc.code}: {detail}"
+        ) from exc
+    except urllib_error.URLError as exc:
+        raise RuntimeError(
+            f"GitHub API request failed for {path}: {exc.reason}"
+        ) from exc
+
+
+def _json_mapping(value: object) -> Mapping[str, object] | None:
+    return value if isinstance(value, Mapping) else None
+
+
+def _setting_payload(
+    *,
+    label: str,
+    path: str,
+    token: str,
+    issues: list[str],
+) -> object | None:
+    try:
+        return _github_api_json(path, token)
+    except RuntimeError as exc:
+        issues.append(f"{label} could not be verified: {exc}")
+        return None
+
+
+def repository_settings_issues(repo_slug: str, token: str) -> tuple[str, ...]:
+    """Return targeted issues for every required release repository setting."""
+
+    issues: list[str] = []
+    encoded_repo = urllib_parse.quote(repo_slug, safe="/")
+    base = f"/repos/{encoded_repo}"
+
+    immutable = _setting_payload(
+        label="immutable releases",
+        path=f"{base}/immutable-releases",
+        token=token,
+        issues=issues,
+    )
+    immutable_mapping = _json_mapping(immutable)
+    if immutable is not None and (
+        immutable_mapping is None or immutable_mapping.get("enabled") is not True
+    ):
+        issues.append("immutable releases must be enabled")
+
+    actions = _setting_payload(
+        label="Actions SHA pinning",
+        path=f"{base}/actions/permissions",
+        token=token,
+        issues=issues,
+    )
+    actions_mapping = _json_mapping(actions)
+    if actions is not None and (
+        actions_mapping is None
+        or actions_mapping.get("sha_pinning_required") is not True
+    ):
+        issues.append("Actions SHA pinning must require full commit SHAs")
+
+    environment = _setting_payload(
+        label="pypi environment policy",
+        path=f"{base}/environments/pypi",
+        token=token,
+        issues=issues,
+    )
+    environment_mapping = _json_mapping(environment)
+    deployment_policy = (
+        _json_mapping(environment_mapping.get("deployment_branch_policy"))
+        if environment_mapping is not None
+        else None
+    )
+    if environment is not None and (
+        deployment_policy is None
+        or deployment_policy.get("protected_branches") is not False
+        or deployment_policy.get("custom_branch_policies") is not True
+    ):
+        issues.append("pypi environment must use custom tag deployment policies only")
+
+    policies = _setting_payload(
+        label="pypi environment tag policies",
+        path=f"{base}/environments/pypi/deployment-branch-policies",
+        token=token,
+        issues=issues,
+    )
+    policies_mapping = _json_mapping(policies)
+    observed_policies: set[tuple[str, str]] = set()
+    raw_policies = (
+        policies_mapping.get("branch_policies")
+        if policies_mapping is not None
+        else None
+    )
+    if isinstance(raw_policies, list):
+        for raw_policy in raw_policies:
+            policy = _json_mapping(raw_policy)
+            if policy is None:
+                continue
+            policy_type = policy.get("type")
+            name = policy.get("name")
+            if isinstance(policy_type, str) and isinstance(name, str):
+                observed_policies.add((policy_type, name))
+    if policies is not None and observed_policies != set(PYPI_ENVIRONMENT_TAG_PATTERNS):
+        issues.append(
+            "pypi environment tag policies must be exactly v*, "
+            "simplebroker_pg/v*, and simplebroker_redis/v*"
+        )
+
+    rulesets = _setting_payload(
+        label="release-tag ruleset",
+        path=f"{base}/rulesets",
+        token=token,
+        issues=issues,
+    )
+    matching_rulesets: list[Mapping[str, object]] = []
+    if isinstance(rulesets, list):
+        matching_rulesets = [
+            ruleset
+            for raw_ruleset in rulesets
+            if (ruleset := _json_mapping(raw_ruleset)) is not None
+            and ruleset.get("name") == RELEASE_TAG_RULESET_NAME
+            and ruleset.get("target") == "tag"
+            and ruleset.get("enforcement") == "active"
+        ]
+    if rulesets is not None and len(matching_rulesets) != 1:
+        issues.append(
+            "release-tag ruleset 'Protect release tags' must exist and be active"
+        )
+    elif len(matching_rulesets) == 1:
+        ruleset_id = matching_rulesets[0].get("id")
+        if not isinstance(ruleset_id, int) or isinstance(ruleset_id, bool):
+            issues.append("release-tag ruleset did not contain a numeric id")
+        else:
+            detail = _setting_payload(
+                label="release-tag ruleset",
+                path=f"{base}/rulesets/{ruleset_id}",
+                token=token,
+                issues=issues,
+            )
+            detail_mapping = _json_mapping(detail)
+            conditions = (
+                _json_mapping(detail_mapping.get("conditions"))
+                if detail_mapping is not None
+                else None
+            )
+            ref_name = (
+                _json_mapping(conditions.get("ref_name"))
+                if conditions is not None
+                else None
+            )
+            includes = ref_name.get("include") if ref_name is not None else None
+            excludes = ref_name.get("exclude") if ref_name is not None else None
+            bypass_actors = (
+                detail_mapping.get("bypass_actors")
+                if detail_mapping is not None
+                else None
+            )
+            raw_rules = (
+                detail_mapping.get("rules") if detail_mapping is not None else None
+            )
+            rule_types: set[str] = set()
+            if isinstance(raw_rules, list):
+                for raw_rule in raw_rules:
+                    rule = _json_mapping(raw_rule)
+                    rule_type = rule.get("type") if rule is not None else None
+                    if isinstance(rule_type, str):
+                        rule_types.add(rule_type)
+            if (
+                not isinstance(includes, list)
+                or {item for item in includes if isinstance(item, str)}
+                != set(RELEASE_TAG_PATTERNS)
+                or excludes != []
+                or bypass_actors != []
+                or rule_types != {"update", "deletion"}
+            ):
+                issues.append(
+                    "release-tag ruleset must block updates and deletions for all "
+                    "release tags, allow creation, and have no bypass actors"
+                )
+
+    return tuple(issues)
+
+
+def require_repository_settings() -> None:
+    """Fail closed unless authenticated GitHub settings match release policy."""
+
+    token = _github_api_token()
+    if not token:
+        raise RuntimeError(
+            "Authenticated GitHub access is required to verify repository settings"
+        )
+    remote_url = origin_remote_url()
+    repo_slug = github_repo_slug_from_remote(remote_url)
+    if repo_slug is None:
+        raise RuntimeError(
+            f"Unable to determine GitHub repository from origin remote: {remote_url}"
+        )
+    issues = repository_settings_issues(repo_slug, token)
+    if issues:
+        raise RuntimeError(
+            "Repository settings are not ready for release:\n- " + "\n- ".join(issues)
+        )
+    print("repository setting ok: immutable releases enabled")
+    print("repository setting ok: release tags are write-once")
+    print("repository setting ok: pypi accepts only release tags")
+    print("repository setting ok: Actions require full SHA pinning")
+
+
 def _url_exists(url: str) -> bool:
     """Return whether a JSON endpoint exists, treating 404 as missing."""
 
@@ -1302,6 +1595,7 @@ def resolve_target_version(
     *,
     current_version: str,
     target: ReleaseTarget,
+    dry_run: bool = False,
 ) -> tuple[str, ReleaseState]:
     """Resolve the target version and ensure it has not been externally published."""
 
@@ -1311,6 +1605,10 @@ def resolve_target_version(
         else validate_version(requested_version)
     )
     state = inspect_release_state(target_version, target=target)
+    if state.published and requested_version is None and dry_run:
+        major, minor, patch = version_tuple(current_version)
+        target_version = f"{major}.{minor}.{patch + 1}"
+        state = inspect_release_state(target_version, target=target)
     if state.published:
         if requested_version is None:
             raise RuntimeError(
@@ -1333,31 +1631,27 @@ def plan_tag_action(
     *,
     head_commit: str,
     version_changed: bool,
-    allow_retag: bool,
 ) -> TagAction:
     """Plan how the helper should handle the target tag safely."""
 
     if version_changed:
         if state.remote_tag_commit is not None:
-            if allow_retag:
-                return "replace_remote"
             raise RuntimeError(
                 f"Tag {state.tag_name} already exists on origin at "
-                f"{_short_commit(state.remote_tag_commit)}. Choose a different version "
-                "or pass --retag."
+                f"{_short_commit(state.remote_tag_commit)}. Choose a new version; "
+                "remote release tags are permanent."
             )
         if state.local_tag_commit is not None:
             return "replace_local"
         return "create"
 
     if state.remote_tag_commit is not None and state.remote_tag_commit != head_commit:
-        if allow_retag:
-            return "replace_remote"
         raise RuntimeError(
             f"Tag {state.tag_name} already exists on origin at "
             f"{_short_commit(state.remote_tag_commit)}, but HEAD is "
             f"{_short_commit(head_commit)}. Reusing this unpublished version "
-            "would move the remote tag; choose a new version or pass --retag."
+            "would move the remote tag. Choose a new version; remote release "
+            "tags are permanent."
         )
 
     if state.local_tag_commit is not None and state.local_tag_commit != head_commit:
@@ -1456,14 +1750,12 @@ def _plan_candidate_tag_actions(
     *,
     head_commit: str,
     version_changed: bool,
-    allow_retag: bool,
 ) -> dict[str, TagAction]:
     return {
         candidate.target.key: plan_tag_action(
             candidate.state,
             head_commit=head_commit,
             version_changed=version_changed,
-            allow_retag=allow_retag,
         )
         for candidate in candidates
     }
@@ -1548,6 +1840,134 @@ def _remote_tag_reuse_note(state: ReleaseState) -> str:
     )
 
 
+def required_workflows_for_targets(
+    targets: tuple[ReleaseTarget, ...],
+) -> tuple[str, ...]:
+    """Return the ordered union of normal workflows required for targets."""
+
+    required: list[str] = []
+    for target in targets:
+        for workflow in REQUIRED_WORKFLOWS_BY_TARGET[target.key]:
+            if workflow not in required:
+                required.append(workflow)
+    return tuple(required)
+
+
+def _github_repo_slug() -> str:
+    remote_url = origin_remote_url()
+    repo_slug = github_repo_slug_from_remote(remote_url)
+    if repo_slug is None:
+        raise RuntimeError(
+            f"Unable to determine GitHub repository from origin remote: {remote_url}"
+        )
+    return repo_slug
+
+
+def wait_for_release_workflows(
+    targets: tuple[ReleaseTarget, ...],
+    release_sha: str,
+    *,
+    dry_run: bool = False,
+) -> None:
+    """Invoke the shared exact-SHA workflow poller without exposing its token."""
+
+    token = "dry-run-authenticated-token"
+    if not dry_run:
+        token = _github_api_token() or ""
+        if not token:
+            raise RuntimeError(
+                "Authenticated GitHub access is required to wait for release CI"
+            )
+    command: list[str] = [
+        sys.executable,
+        ".github/scripts/require_green_workflows.py",
+        "--repo",
+        _github_repo_slug(),
+        "--sha",
+        release_sha,
+    ]
+    for workflow in required_workflows_for_targets(targets):
+        command.extend(("--workflow", workflow))
+    run_command(
+        tuple(command),
+        dry_run=dry_run,
+        env_overrides={"GITHUB_TOKEN": token},
+        sensitive_env_keys=frozenset({"GITHUB_TOKEN"}),
+    )
+
+
+def require_release_sha_on_origin_main(
+    release_sha: str,
+    *,
+    dry_run: bool = False,
+) -> None:
+    """Fetch main and require it still contains the tested release commit."""
+
+    run_command(("git", "fetch", "origin", "main"), dry_run=dry_run)
+    if dry_run:
+        print(
+            "dry-run: would require the tested release SHA to remain reachable "
+            "from origin/main"
+        )
+        return
+    result = _capture_command(
+        ("git", "merge-base", "--is-ancestor", release_sha, "origin/main")
+    )
+    if result.returncode == 0:
+        return
+    if result.returncode == 1:
+        raise RuntimeError(
+            f"Tested release SHA {release_sha} is no longer reachable from origin/main"
+        )
+    detail = result.stderr.strip() or result.stdout.strip() or "unknown git error"
+    raise RuntimeError(f"Unable to verify origin/main ancestry: {detail}")
+
+
+def publish_release_tags_after_ci(
+    candidates: tuple[ReleaseCandidate, ...],
+    release_sha: str,
+    *,
+    dry_run: bool = False,
+) -> None:
+    """Push main, wait for exact-SHA CI, then create and push final tags."""
+
+    targets = _candidate_targets(candidates)
+    run_command(("git", "push", "origin", "main"), dry_run=dry_run)
+    wait_for_release_workflows(targets, release_sha, dry_run=dry_run)
+    require_release_sha_on_origin_main(release_sha, dry_run=dry_run)
+
+    for candidate in candidates:
+        state = (
+            candidate.state
+            if dry_run
+            else inspect_release_state(
+                candidate.release_version,
+                target=candidate.target,
+            )
+        )
+        if state.published:
+            raise RuntimeError(
+                f"{candidate.target.display_name} {candidate.release_version} was "
+                f"published during the pre-tag wait via {published_destinations(state)}"
+            )
+        tag_action = plan_tag_action(
+            state,
+            head_commit=release_sha,
+            version_changed=False,
+        )
+        _prepare_tag_action(
+            state,
+            tag_action=tag_action,
+            dry_run=dry_run,
+            target_commit=release_sha,
+        )
+        _push_tag_action(
+            state,
+            tag_action=tag_action,
+            dry_run=dry_run,
+        )
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Create a local SimpleBroker release")
     parser.add_argument(
@@ -1590,12 +2010,9 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Print planned actions without modifying files or running commands",
     )
     parser.add_argument(
-        "--retag",
+        "--check-repository-settings",
         action="store_true",
-        help=(
-            "Delete and recreate unpublished remote tags when the existing tag "
-            "points at the wrong commit."
-        ),
+        help="Read and verify release-related GitHub repository settings",
     )
     parser.add_argument(
         "--check-shell-examples",
@@ -1610,20 +2027,19 @@ def _prepare_tag_action(
     *,
     tag_action: TagAction,
     dry_run: bool,
+    target_commit: str,
 ) -> None:
-    """Apply local tag mutations and remote tag deletions."""
+    """Apply local-only tag mutations after exact-SHA CI succeeds."""
 
     tag_name = state.tag_name
     if tag_action == "replace_local":
         run_command(("git", "tag", "-d", tag_name), dry_run=dry_run)
 
-    if tag_action == "replace_remote":
-        if state.local_tag_commit is not None:
-            run_command(("git", "tag", "-d", tag_name), dry_run=dry_run)
-        run_command(("git", "push", "--delete", "origin", tag_name), dry_run=dry_run)
-
-    if tag_action in {"create", "replace_local", "replace_remote"}:
-        run_command(("git", "tag", tag_name), dry_run=dry_run)
+    if tag_action in {"create", "replace_local"}:
+        run_command(
+            ("git", "tag", tag_name, target_commit),
+            dry_run=dry_run,
+        )
 
 
 def _push_tag_action(
@@ -1635,7 +2051,7 @@ def _push_tag_action(
     """Push a prepared tag to origin when required."""
 
     tag_name = state.tag_name
-    if tag_action in {"create", "push_local", "replace_local", "replace_remote"}:
+    if tag_action in {"create", "push_local", "replace_local"}:
         run_command(("git", "push", "origin", tag_name), dry_run=dry_run)
         return
 
@@ -1681,11 +2097,12 @@ def _run_batch_release(args: argparse.Namespace) -> int:
         candidates,
         head_commit=initial_head_commit,
         version_changed=False,
-        allow_retag=args.retag,
     )
     _print_batch_release_plan(candidates, tag_actions)
 
     if args.dry_run:
+        print("dry-run: would require the current branch to be main")
+        print("dry-run: would verify authenticated repository release settings")
         if dirty:
             print("dry-run: working tree is dirty; a real release would fail")
         if args.publish:
@@ -1713,25 +2130,19 @@ def _run_batch_release(args: argparse.Namespace) -> int:
             ("git", "commit", "-m", _batch_release_commit_message(candidates)),
             dry_run=True,
         )
-        for candidate in candidates:
-            _prepare_tag_action(
-                candidate.state,
-                tag_action=tag_actions[candidate.target.key],
-                dry_run=True,
-            )
-        run_command(("git", "push"), dry_run=True)
-        for candidate in candidates:
-            _push_tag_action(
-                candidate.state,
-                tag_action=tag_actions[candidate.target.key],
-                dry_run=True,
-            )
+        publish_release_tags_after_ci(
+            candidates,
+            PENDING_RELEASE_COMMIT,
+            dry_run=True,
+        )
         print(
-            "dry-run: next step is to wait for release workflows on "
+            "dry-run: tag pushes would start draft-first release workflows on "
             + ", ".join(candidate.state.tag_name for candidate in candidates)
         )
         return 0
 
+    require_main_branch()
+    require_repository_settings()
     _require_command("uv")
     if args.publish:
         _print_publish_note()
@@ -1771,27 +2182,8 @@ def _run_batch_release(args: argparse.Namespace) -> int:
     else:
         print("No release commit needed; release files already match target versions")
 
-    head_commit = current_head_commit()
-    tag_actions = _plan_candidate_tag_actions(
-        candidates,
-        head_commit=head_commit,
-        version_changed=release_commit_created,
-        allow_retag=args.retag,
-    )
-
-    for candidate in candidates:
-        _prepare_tag_action(
-            candidate.state,
-            tag_action=tag_actions[candidate.target.key],
-            dry_run=False,
-        )
-    run_command(("git", "push"))
-    for candidate in candidates:
-        _push_tag_action(
-            candidate.state,
-            tag_action=tag_actions[candidate.target.key],
-            dry_run=False,
-        )
+    release_sha = current_head_commit()
+    publish_release_tags_after_ci(candidates, release_sha)
 
     print(
         "Next step: wait for release-gate workflows on "
@@ -1806,6 +2198,9 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
     if args.check_shell_examples:
         return run_shellcheck_examples()
+    if args.check_repository_settings:
+        require_repository_settings()
+        return 0
     if args.target == ALL_RELEASE_TARGET_KEY:
         return _run_batch_release(args)
 
@@ -1822,6 +2217,7 @@ def main(argv: list[str] | None = None) -> int:
         args.version,
         current_version=current_version,
         target=target,
+        dry_run=args.dry_run,
     )
     version_changed = target_version != current_version
     initial_head_commit = current_head_commit()
@@ -1832,7 +2228,6 @@ def main(argv: list[str] | None = None) -> int:
         release_state,
         head_commit=planning_head_commit,
         version_changed=version_changed,
-        allow_retag=args.retag,
     )
 
     print(f"target:  {target.display_name}")
@@ -1842,6 +2237,8 @@ def main(argv: list[str] | None = None) -> int:
     print(f"tag:     {release_state.tag_name} ({tag_action})")
 
     if args.dry_run:
+        print("dry-run: would require the current branch to be main")
+        print("dry-run: would verify authenticated repository release settings")
         if dirty:
             print("dry-run: working tree is dirty; a real release would fail")
         if args.publish:
@@ -1904,15 +2301,25 @@ def main(argv: list[str] | None = None) -> int:
                 "dry-run: no release commit needed unless generated release files "
                 "change during post-update checks"
             )
-        _prepare_tag_action(release_state, tag_action=tag_action, dry_run=True)
-        run_command(("git", "push"), dry_run=True)
-        _push_tag_action(release_state, tag_action=tag_action, dry_run=True)
+        candidate = ReleaseCandidate(
+            target=target,
+            current_version=current_version,
+            release_version=target_version,
+            state=release_state,
+        )
+        publish_release_tags_after_ci(
+            (candidate,),
+            PENDING_RELEASE_COMMIT,
+            dry_run=True,
+        )
         print(
-            "dry-run: next step is to wait for "
+            "dry-run: the tag push would start the draft-first workflow "
             f"{target.release_workflow} on {release_state.tag_name}"
         )
         return 0
 
+    require_main_branch()
+    require_repository_settings()
     _require_command("uv")
     if args.publish:
         _print_publish_note()
@@ -1971,17 +2378,14 @@ def main(argv: list[str] | None = None) -> int:
     else:
         print("No release commit needed; release files already match target version")
 
-    head_commit = current_head_commit()
-    tag_action = plan_tag_action(
-        release_state,
-        head_commit=head_commit,
-        version_changed=release_commit_created,
-        allow_retag=args.retag,
+    release_sha = current_head_commit()
+    candidate = ReleaseCandidate(
+        target=target,
+        current_version=current_version,
+        release_version=target_version,
+        state=release_state,
     )
-
-    _prepare_tag_action(release_state, tag_action=tag_action, dry_run=False)
-    run_command(("git", "push"))
-    _push_tag_action(release_state, tag_action=tag_action, dry_run=False)
+    publish_release_tags_after_ci((candidate,), release_sha)
 
     print(
         "Next step: wait for "

--- a/docs/plans/2026-07-12-release-reproducibility-and-publication-hardening-plan.md
+++ b/docs/plans/2026-07-12-release-reproducibility-and-publication-hardening-plan.md
@@ -354,6 +354,12 @@ Use `uv run --locked` for these local bootstrap helpers. In already-synced CI
 steps, use `uv run --frozen --no-sync` where no nested helper needs to change the
 environment.
 
+Run local pytest release gates with one worker more than the available logical
+CPU count. `bin/release.py` calculates `(os.cpu_count() or 1) + 1`; ad hoc plan
+gates use the same calculation. This preserves the prior small worker
+oversubscription. Do not serialize local gates to avoid exposing contention;
+hosted CI remains the stricter timing environment.
+
 ## Dependency and Execution Order
 
 ```text
@@ -543,7 +549,8 @@ Add tests that require:
 
 ```bash
 python bin/bump_uv.py --check
-uv run pytest -q -n0 \
+PYTEST_WORKERS="$(python -c 'import os; print((os.cpu_count() or 1) + 1)')"
+uv run pytest -q -n "$PYTEST_WORKERS" \
   tests/test_bump_uv.py \
   tests/test_release_workflow.py \
   tests/test_dev_scripts.py \
@@ -608,7 +615,8 @@ Add tests that fail until:
 ```bash
 uv lock --check
 uv run ./bin/packaging-smoke --python 3.11
-uv run pytest -q -n0 \
+PYTEST_WORKERS="$(python -c 'import os; print((os.cpu_count() or 1) + 1)')"
+uv run pytest -q -n "$PYTEST_WORKERS" \
   tests/test_release_workflow.py \
   tests/test_release_script.py \
   tests/test_dev_scripts.py
@@ -811,7 +819,8 @@ Tests must also prove:
 ### Gates
 
 ```bash
-uv run pytest -q -n0 \
+PYTEST_WORKERS="$(python -c 'import os; print((os.cpu_count() or 1) + 1)')"
+uv run pytest -q -n "$PYTEST_WORKERS" \
   tests/test_release_script.py \
   tests/test_release_publication_script.py \
   tests/test_release_workflow.py
@@ -855,7 +864,8 @@ Tests first:
 Gate:
 
 ```bash
-uv run pytest -q -n0 tests/test_release_workflow.py \
+PYTEST_WORKERS="$(python -c 'import os; print((os.cpu_count() or 1) + 1)')"
+uv run pytest -q -n "$PYTEST_WORKERS" tests/test_release_workflow.py \
   -k 'codecov or coverage'
 ```
 
@@ -877,7 +887,7 @@ workflow. Cover the flag in `tests/test_release_script.py`.
 Then add these to the existing lint/quality job after its frozen sync:
 
 ```bash
-uv run --frozen --no-sync pytest -n0 examples
+uv run --frozen --no-sync pytest -n auto examples
 uv run --frozen --no-sync python bin/release.py --check-example-types
 ```
 
@@ -1062,13 +1072,14 @@ policies, and Actions SHA enforcement.
 
 ```bash
 python bin/bump_uv.py --check
-uv run pytest -q -n0 \
+PYTEST_WORKERS="$(python -c 'import os; print((os.cpu_count() or 1) + 1)')"
+uv run pytest -q -n "$PYTEST_WORKERS" \
   tests/test_bump_uv.py \
   tests/test_release_publication_script.py \
   tests/test_release_workflow.py \
   tests/test_release_script.py \
   tests/test_dev_scripts.py
-uv run pytest
+uv run pytest -n "$PYTEST_WORKERS"
 uv run ruff check simplebroker tests bin .github/scripts \
   extensions/simplebroker_pg/simplebroker_pg \
   extensions/simplebroker_pg/tests \
@@ -1290,7 +1301,7 @@ from YAML or local tests alone.
 | Shared draft-first release flow | Pending | Shared-script tests and all three merged job dependency graphs |
 | PR C: CI quick wins | Pending | Focused PR diff, coverage/example workflow output, and warning-path test |
 | Codecov OIDC | Pending | At least one successful authenticated PR or `main` upload URL; warning-bearing outage run if encountered |
-| Example CI | Pending | `pytest -n0 examples` and example mypy job output |
+| Example CI | Pending | `pytest -n auto examples` and example mypy job output |
 | Actions policy | Pending | Authenticated permissions and selected-actions readback |
 | PyPI environment policy | Pending | Environment and tag-policy readback |
 | Release tag ruleset | Pending | Active tag ruleset readback with no bypass |

--- a/tests/test_release_publication_script.py
+++ b/tests/test_release_publication_script.py
@@ -1,0 +1,439 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+def _load_publication_module() -> ModuleType:
+    path = (
+        Path(__file__).resolve().parents[1]
+        / ".github"
+        / "scripts"
+        / "release_publication.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "simplebroker_release_publication",
+        path,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+publication = _load_publication_module()
+
+
+def _release(
+    *,
+    draft: bool = True,
+    immutable: bool = False,
+    assets: tuple[str, ...] = (
+        "package.whl",
+        "package.tar.gz",
+        "bundle.sigstore.json",
+    ),
+) -> dict[str, object]:
+    return {
+        "id": 17,
+        "tag_name": "v1.2.3",
+        "target_commitish": "main",
+        "draft": draft,
+        "immutable": immutable,
+        "assets": [{"name": name, "state": "uploaded"} for name in assets],
+    }
+
+
+def test_release_listing_discovers_drafts_by_tag_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[str, str]] = []
+
+    def request(
+        method: str,
+        path: str,
+        *,
+        token: str,
+        body: object = None,
+    ) -> object:
+        calls.append((method, path))
+        return [_release(), {**_release(), "id": 18, "tag_name": "v9.9.9"}]
+
+    monkeypatch.setattr(publication, "github_api_request", request)
+
+    releases = publication.list_releases("VanL/simplebroker", "token")
+    matches = publication.matching_releases(releases, "v1.2.3")
+
+    assert [release["id"] for release in matches] == [17]
+    assert calls == [("GET", "/repos/VanL/simplebroker/releases?per_page=100&page=1")]
+    assert all("/releases/tags/" not in path for _, path in calls)
+
+
+def test_replace_draft_deletes_only_the_matching_draft(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[str, str, object]] = []
+    monkeypatch.setattr(
+        publication,
+        "resolve_tag_commit",
+        lambda repo, tag, token: "a" * 40,
+    )
+    monkeypatch.setattr(publication, "list_releases", lambda repo, token: (_release(),))
+
+    def request(
+        method: str,
+        path: str,
+        *,
+        token: str,
+        body: object = None,
+    ) -> None:
+        calls.append((method, path, body))
+
+    monkeypatch.setattr(publication, "github_api_request", request)
+
+    publication.replace_draft(
+        repo="VanL/simplebroker",
+        tag="v1.2.3",
+        expected_sha="a" * 40,
+        token="token",
+    )
+
+    assert calls == [("DELETE", "/repos/VanL/simplebroker/releases/17", None)]
+
+
+def test_replace_draft_never_deletes_a_published_release(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        publication,
+        "resolve_tag_commit",
+        lambda repo, tag, token: "a" * 40,
+    )
+    monkeypatch.setattr(
+        publication,
+        "list_releases",
+        lambda repo, token: (_release(draft=False, immutable=True),),
+    )
+    monkeypatch.setattr(
+        publication,
+        "github_api_request",
+        lambda *args, **kwargs: pytest.fail("published release must not be deleted"),
+    )
+
+    with pytest.raises(RuntimeError, match="published release"):
+        publication.replace_draft(
+            repo="VanL/simplebroker",
+            tag="v1.2.3",
+            expected_sha="a" * 40,
+            token="token",
+        )
+
+
+def test_tag_resolution_peels_annotated_tags_independently(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+
+    def request(
+        method: str,
+        path: str,
+        *,
+        token: str,
+        body: object = None,
+    ) -> object:
+        calls.append(path)
+        if "/git/ref/tags/" in path:
+            return {"object": {"type": "tag", "sha": "b" * 40}}
+        return {"object": {"type": "commit", "sha": "a" * 40}}
+
+    monkeypatch.setattr(publication, "github_api_request", request)
+
+    assert (
+        publication.resolve_tag_commit("VanL/simplebroker", "v1.2.3", "token")
+        == "a" * 40
+    )
+    assert calls == [
+        "/repos/VanL/simplebroker/git/ref/tags/v1.2.3",
+        f"/repos/VanL/simplebroker/git/tags/{'b' * 40}",
+    ]
+
+
+def test_wrong_remote_tag_sha_is_always_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        publication,
+        "resolve_tag_commit",
+        lambda repo, tag, token: "b" * 40,
+    )
+
+    with pytest.raises(RuntimeError, match="does not match expected release SHA"):
+        publication.replace_draft(
+            repo="VanL/simplebroker",
+            tag="v1.2.3",
+            expected_sha="a" * 40,
+            token="token",
+        )
+
+
+def test_exact_asset_set_rejects_missing_extra_and_duplicate_assets() -> None:
+    expected = ("package.whl", "package.tar.gz", "bundle.sigstore.json")
+
+    publication.require_exact_assets(_release(), expected)
+
+    for assets in (
+        ("package.whl", "package.tar.gz"),
+        (
+            "package.whl",
+            "package.tar.gz",
+            "bundle.sigstore.json",
+            "extra.txt",
+        ),
+        (
+            "package.whl",
+            "package.whl",
+            "package.tar.gz",
+            "bundle.sigstore.json",
+        ),
+    ):
+        with pytest.raises(RuntimeError, match="asset set"):
+            publication.require_exact_assets(_release(assets=assets), expected)
+
+
+@pytest.mark.parametrize(
+    "expected",
+    (
+        ("package.whl", "bundle.json"),
+        ("package.tar.gz", "bundle.json"),
+        ("package.whl", "package.tar.gz"),
+        (
+            "package.whl",
+            "other.whl",
+            "package.tar.gz",
+            "bundle.sigstore.json",
+        ),
+    ),
+)
+def test_expected_assets_require_one_wheel_sdist_and_sigstore_bundle(
+    expected: tuple[str, ...],
+) -> None:
+    release = _release(assets=expected)
+
+    with pytest.raises(RuntimeError, match="one wheel, one sdist, and one Sigstore"):
+        publication.require_exact_assets(release, expected)
+
+
+def test_publish_draft_verifies_assets_then_publishes_without_pypi_poll(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[str, str, object]] = []
+    monkeypatch.setattr(
+        publication,
+        "resolve_tag_commit",
+        lambda repo, tag, token: "a" * 40,
+    )
+    monkeypatch.setattr(publication, "list_releases", lambda repo, token: (_release(),))
+    monkeypatch.setattr(
+        publication,
+        "wait_for_pypi",
+        lambda *args, **kwargs: pytest.fail("a draft follows a successful PyPI job"),
+    )
+
+    def request(
+        method: str,
+        path: str,
+        *,
+        token: str,
+        body: object = None,
+    ) -> dict[str, object]:
+        calls.append((method, path, body))
+        return {**_release(), "draft": False, "immutable": True}
+
+    monkeypatch.setattr(publication, "github_api_request", request)
+
+    publication.publish_draft(
+        repo="VanL/simplebroker",
+        tag="v1.2.3",
+        expected_sha="a" * 40,
+        package="simplebroker",
+        version="1.2.3",
+        expected_assets=(
+            "package.whl",
+            "package.tar.gz",
+            "bundle.sigstore.json",
+        ),
+        token="token",
+    )
+
+    assert calls == [
+        (
+            "PATCH",
+            "/repos/VanL/simplebroker/releases/17",
+            {"draft": False},
+        )
+    ]
+
+
+@pytest.mark.parametrize("releases", ((), (_release(), _release())))
+def test_publish_draft_fails_closed_on_missing_or_duplicate_state(
+    monkeypatch: pytest.MonkeyPatch,
+    releases: tuple[dict[str, object], ...],
+) -> None:
+    monkeypatch.setattr(
+        publication,
+        "resolve_tag_commit",
+        lambda repo, tag, token: "a" * 40,
+    )
+    monkeypatch.setattr(publication, "list_releases", lambda repo, token: releases)
+
+    with pytest.raises(RuntimeError, match="exactly one GitHub Release"):
+        publication.publish_draft(
+            repo="VanL/simplebroker",
+            tag="v1.2.3",
+            expected_sha="a" * 40,
+            package="simplebroker",
+            version="1.2.3",
+            expected_assets=(
+                "package.whl",
+                "package.tar.gz",
+                "bundle.sigstore.json",
+            ),
+            token="token",
+        )
+
+
+def test_already_published_immutable_release_is_exact_rerun_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pypi_calls: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        publication,
+        "resolve_tag_commit",
+        lambda repo, tag, token: "a" * 40,
+    )
+    monkeypatch.setattr(
+        publication,
+        "list_releases",
+        lambda repo, token: (_release(draft=False, immutable=True),),
+    )
+    monkeypatch.setattr(
+        publication,
+        "wait_for_pypi",
+        lambda package, version: pypi_calls.append((package, version)),
+    )
+    monkeypatch.setattr(
+        publication,
+        "github_api_request",
+        lambda *args, **kwargs: pytest.fail("published release must not be edited"),
+    )
+
+    publication.publish_draft(
+        repo="VanL/simplebroker",
+        tag="v1.2.3",
+        expected_sha="a" * 40,
+        package="simplebroker",
+        version="1.2.3",
+        expected_assets=(
+            "package.whl",
+            "package.tar.gz",
+            "bundle.sigstore.json",
+        ),
+        token="token",
+    )
+
+    assert pypi_calls == [("simplebroker", "1.2.3")]
+
+
+def test_already_published_mutable_release_is_not_rerun_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        publication,
+        "resolve_tag_commit",
+        lambda repo, tag, token: "a" * 40,
+    )
+    monkeypatch.setattr(
+        publication,
+        "list_releases",
+        lambda repo, token: (_release(draft=False, immutable=False),),
+    )
+
+    with pytest.raises(RuntimeError, match="not immutable"):
+        publication.publish_draft(
+            repo="VanL/simplebroker",
+            tag="v1.2.3",
+            expected_sha="a" * 40,
+            package="simplebroker",
+            version="1.2.3",
+            expected_assets=(
+                "package.whl",
+                "package.tar.gz",
+                "bundle.sigstore.json",
+            ),
+            token="token",
+        )
+
+
+def test_pypi_poll_is_bounded_to_five_attempts_over_a_few_minutes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    states = iter(
+        (
+            (False, "HTTP 404"),
+            (False, "HTTP 404"),
+            (False, "HTTP 404"),
+            (False, "HTTP 404"),
+            (True, "simplebroker 1.2.3"),
+        )
+    )
+    sleeps: list[int] = []
+    monkeypatch.setattr(
+        publication,
+        "pypi_release_state",
+        lambda package, version: next(states),
+    )
+    monkeypatch.setattr(publication.time, "sleep", sleeps.append)
+
+    publication.wait_for_pypi("simplebroker", "1.2.3")
+
+    assert sleeps == list(publication.PYPI_RETRY_DELAYS)
+    assert len(sleeps) == 4
+    assert 120 <= sum(sleeps) <= 300
+
+
+def test_pypi_poll_failure_reports_last_observed_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    states = iter((False, f"attempt {attempt}") for attempt in range(1, 6))
+    monkeypatch.setattr(
+        publication,
+        "pypi_release_state",
+        lambda package, version: next(states),
+    )
+    monkeypatch.setattr(publication.time, "sleep", lambda delay: None)
+
+    with pytest.raises(RuntimeError, match="attempt 5"):
+        publication.wait_for_pypi("simplebroker", "1.2.3")
+
+
+def test_cli_never_accepts_a_token_argument() -> None:
+    parser = publication.build_parser()
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(
+            [
+                "replace-draft",
+                "--repo",
+                "VanL/simplebroker",
+                "--tag",
+                "v1.2.3",
+                "--expected-sha",
+                "a" * 40,
+                "--token",
+                "secret",
+            ]
+        )

--- a/tests/test_release_script.py
+++ b/tests/test_release_script.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 import os
+import subprocess
 import sys
 from pathlib import Path
 from types import ModuleType
@@ -58,8 +59,50 @@ def test_release_targets_format_expected_tags() -> None:
     assert "redis" in release.RELEASE_TARGETS
 
 
+def test_bare_dry_run_previews_next_patch_when_current_version_is_published(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def inspect(version: str, *, target: release.ReleaseTarget) -> release.ReleaseState:
+        return release.ReleaseState(
+            target=target,
+            version=version,
+            tag_name=target.tag_name(version),
+            github_release_exists=version == "5.3.1",
+            pypi_release_exists=version == "5.3.1",
+            local_tag_commit=None,
+            remote_tag_commit=None,
+        )
+
+    monkeypatch.setattr(release, "inspect_release_state", inspect)
+
+    version, state = release.resolve_target_version(
+        None,
+        current_version="5.3.1",
+        target=release.ROOT_RELEASE_TARGET,
+        dry_run=True,
+    )
+
+    assert version == "5.3.2"
+    assert state.published is False
+
+
 def _commands_text(commands: tuple[tuple[str, ...], ...]) -> str:
     return "\n".join(" ".join(command) for command in commands)
+
+
+def test_local_release_gate_uses_logical_cpus_plus_one_worker() -> None:
+    assert release._local_pytest_worker_count(8) == 9
+    assert release._local_pytest_worker_count(1) == 2
+    assert release._local_pytest_worker_count(0) == 2
+    assert (
+        f"-n {release.LOCAL_PYTEST_WORKERS} --dist loadgroup"
+        in release.ROOT_TEST_PYTEST_ARGS[-1]
+    )
+    assert release.EXAMPLE_TEST_COMMAND[-3:] == (
+        "-n",
+        str(release.LOCAL_PYTEST_WORKERS),
+        "examples",
+    )
 
 
 def _command_lines(commands: tuple[tuple[str, ...], ...]) -> list[str]:
@@ -269,7 +312,7 @@ def test_redis_prechecks_are_target_scoped() -> None:
     mypy_commands = [command for command in command_lines if " mypy " in f" {command} "]
 
     assert "./bin/pytest-redis" in text
-    assert "pytest -n0 examples" in text
+    assert f"pytest -n {release.LOCAL_PYTEST_WORKERS} examples" in text
     assert "./bin/release.py --check-shell-examples" in text
     assert "mypy examples/" in text
     assert any(
@@ -295,7 +338,7 @@ def test_pg_prechecks_are_target_scoped() -> None:
     mypy_commands = [command for command in command_lines if " mypy " in f" {command} "]
 
     assert "./bin/pytest-pg" in text
-    assert "pytest -n0 examples" in text
+    assert f"pytest -n {release.LOCAL_PYTEST_WORKERS} examples" in text
     assert "./bin/release.py --check-shell-examples" in text
     assert "mypy examples/" in text
     assert any(
@@ -322,7 +365,7 @@ def test_core_prechecks_cover_both_extensions() -> None:
 
     assert "./bin/pytest-pg" in text
     assert "./bin/pytest-redis" in text
-    assert "pytest -n0 examples" in text
+    assert f"pytest -n {release.LOCAL_PYTEST_WORKERS} examples" in text
     assert "./bin/release.py --check-shell-examples" in text
     assert "mypy examples/" in text
     assert any(
@@ -356,7 +399,13 @@ def test_batch_prechecks_deduplicate_shared_checks() -> None:
     assert sum("./bin/pytest-pg" in command for command in command_lines) == 1
     assert sum("./bin/pytest-redis" in command for command in command_lines) == 1
     assert sum(" pytest " in f" {command} " for command in command_lines) == 2
-    assert sum("pytest -n0 examples" in command for command in command_lines) == 1
+    assert (
+        sum(
+            f"pytest -n {release.LOCAL_PYTEST_WORKERS} examples" in command
+            for command in command_lines
+        )
+        == 1
+    )
     assert (
         sum(
             "./bin/release.py --check-shell-examples" in command
@@ -924,7 +973,6 @@ def test_plan_tag_action_for_new_or_matching_tags() -> None:
             _state(),
             head_commit=head,
             version_changed=False,
-            allow_retag=False,
         )
         == "create"
     )
@@ -933,7 +981,6 @@ def test_plan_tag_action_for_new_or_matching_tags() -> None:
             _state(local=head),
             head_commit=head,
             version_changed=False,
-            allow_retag=False,
         )
         == "push_local"
     )
@@ -942,7 +989,6 @@ def test_plan_tag_action_for_new_or_matching_tags() -> None:
             _state(remote=head),
             head_commit=head,
             version_changed=False,
-            allow_retag=False,
         )
         == "reuse_remote"
     )
@@ -952,23 +998,13 @@ def test_plan_tag_action_rejects_remote_tag_at_different_commit() -> None:
     head = "a" * 40
     remote = "b" * 40
 
-    with pytest.raises(RuntimeError, match="already exists on origin"):
+    with pytest.raises(RuntimeError, match="already exists on origin") as exc:
         release.plan_tag_action(
             _state(remote=remote),
             head_commit=head,
             version_changed=False,
-            allow_retag=False,
         )
-
-    assert (
-        release.plan_tag_action(
-            _state(remote=remote),
-            head_commit=head,
-            version_changed=False,
-            allow_retag=True,
-        )
-        == "replace_remote"
-    )
+    assert "Choose a new version" in str(exc.value)
 
 
 def test_plan_tag_action_replaces_local_tag_when_new_release_commit_is_expected() -> (
@@ -981,7 +1017,482 @@ def test_plan_tag_action_replaces_local_tag_when_new_release_commit_is_expected(
             _state(local=old_commit),
             head_commit=release.PENDING_RELEASE_COMMIT,
             version_changed=True,
-            allow_retag=False,
         )
         == "replace_local"
     )
+
+
+def test_retag_option_is_removed() -> None:
+    parser = release._build_parser()
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--retag"])
+
+
+def test_repository_settings_command_is_standalone() -> None:
+    args = release._build_parser().parse_args(["--check-repository-settings"])
+
+    assert args.check_repository_settings is True
+
+
+def test_required_workflows_are_target_specific() -> None:
+    assert release.required_workflows_for_targets((release.ROOT_RELEASE_TARGET,)) == (
+        "Test",
+        "Test Postgres Extension",
+        "Test Redis Extension",
+    )
+    assert release.required_workflows_for_targets((release.PG_RELEASE_TARGET,)) == (
+        "Test",
+        "Test Postgres Extension",
+    )
+    assert release.required_workflows_for_targets((release.REDIS_RELEASE_TARGET,)) == (
+        "Test",
+        "Test Redis Extension",
+    )
+    assert release.required_workflows_for_targets(
+        (
+            release.PG_RELEASE_TARGET,
+            release.REDIS_RELEASE_TARGET,
+            release.ROOT_RELEASE_TARGET,
+        )
+    ) == (
+        "Test",
+        "Test Postgres Extension",
+        "Test Redis Extension",
+    )
+
+
+def test_workflow_wait_passes_token_only_through_redacted_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[tuple[str, ...], dict[str, object]]] = []
+
+    def record(command: tuple[str, ...], **kwargs: object) -> None:
+        calls.append((command, kwargs))
+
+    monkeypatch.setattr(release, "_github_api_token", lambda: "top-secret-token")
+    monkeypatch.setattr(
+        release,
+        "origin_remote_url",
+        lambda: "git@github.com:VanL/simplebroker.git",
+    )
+    monkeypatch.setattr(release, "run_command", record)
+
+    release.wait_for_release_workflows(
+        (release.PG_RELEASE_TARGET,),
+        "a" * 40,
+    )
+
+    assert len(calls) == 1
+    command, kwargs = calls[0]
+    assert ".github/scripts/require_green_workflows.py" in command
+    assert command.count("--workflow") == 2
+    assert "Test" in command
+    assert "Test Postgres Extension" in command
+    assert "top-secret-token" not in " ".join(command)
+    assert kwargs["env_overrides"] == {"GITHUB_TOKEN": "top-secret-token"}
+    assert kwargs["sensitive_env_keys"] == frozenset({"GITHUB_TOKEN"})
+
+
+def test_sensitive_command_environment_is_redacted() -> None:
+    rendered = release._format_command_prefix(
+        {"GITHUB_TOKEN": "top-secret-token", "SAFE": "visible"},
+        sensitive_env_keys=frozenset({"GITHUB_TOKEN"}),
+    )
+
+    assert "top-secret-token" not in rendered
+    assert "GITHUB_TOKEN=<redacted>" in rendered
+    assert "SAFE=visible" in rendered
+
+
+def test_release_sha_must_remain_reachable_from_fetched_main(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    commands: list[tuple[str, ...]] = []
+    sha = "a" * 40
+    monkeypatch.setattr(
+        release,
+        "run_command",
+        lambda command, **kwargs: commands.append(command),
+    )
+    monkeypatch.setattr(
+        release,
+        "_capture_command",
+        lambda command, **kwargs: subprocess.CompletedProcess(command, 0, "", ""),
+    )
+
+    release.require_release_sha_on_origin_main(sha)
+
+    assert commands == [("git", "fetch", "origin", "main")]
+
+
+def test_release_sha_removed_from_main_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sha = "a" * 40
+    monkeypatch.setattr(release, "run_command", lambda command, **kwargs: None)
+    monkeypatch.setattr(
+        release,
+        "_capture_command",
+        lambda command, **kwargs: subprocess.CompletedProcess(command, 1, "", ""),
+    )
+
+    with pytest.raises(RuntimeError, match="no longer reachable from origin/main"):
+        release.require_release_sha_on_origin_main(sha)
+
+
+def test_tag_creation_happens_after_push_and_exact_sha_ci(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sha = "a" * 40
+    candidate = release.ReleaseCandidate(
+        target=release.ROOT_RELEASE_TARGET,
+        current_version="5.3.2",
+        release_version="5.3.2",
+        state=_state(),
+    )
+    events: list[str] = []
+
+    def record(command: tuple[str, ...], **kwargs: object) -> None:
+        events.append("command:" + " ".join(command))
+
+    monkeypatch.setattr(release, "run_command", record)
+    monkeypatch.setattr(
+        release,
+        "wait_for_release_workflows",
+        lambda targets, release_sha, **kwargs: events.append("wait:" + release_sha),
+    )
+    monkeypatch.setattr(
+        release,
+        "require_release_sha_on_origin_main",
+        lambda release_sha, **kwargs: events.append("ancestry:" + release_sha),
+    )
+    monkeypatch.setattr(
+        release,
+        "inspect_release_state",
+        lambda version, target: _state(),
+    )
+
+    release.publish_release_tags_after_ci((candidate,), sha)
+
+    assert events == [
+        "command:git push origin main",
+        f"wait:{sha}",
+        f"ancestry:{sha}",
+        f"command:git tag v3.1.10 {sha}",
+        "command:git push origin v3.1.10",
+    ]
+
+
+@pytest.mark.parametrize(
+    "message",
+    (
+        "required workflow run failed",
+        "required workflow run was cancelled",
+        "required workflow run was not found",
+        "timed out waiting for required workflow runs",
+    ),
+)
+def test_failed_pre_tag_ci_creates_no_tag(
+    monkeypatch: pytest.MonkeyPatch,
+    message: str,
+) -> None:
+    candidate = release.ReleaseCandidate(
+        target=release.ROOT_RELEASE_TARGET,
+        current_version="5.3.2",
+        release_version="5.3.2",
+        state=_state(),
+    )
+    commands: list[tuple[str, ...]] = []
+    monkeypatch.setattr(
+        release,
+        "run_command",
+        lambda command, **kwargs: commands.append(command),
+    )
+
+    def fail(*args: object, **kwargs: object) -> None:
+        raise RuntimeError(message)
+
+    monkeypatch.setattr(release, "wait_for_release_workflows", fail)
+
+    with pytest.raises(RuntimeError, match=message):
+        release.publish_release_tags_after_ci((candidate,), "a" * 40)
+
+    assert commands == [("git", "push", "origin", "main")]
+
+
+def _repository_settings_payloads() -> dict[str, object]:
+    return {
+        "/repos/VanL/simplebroker/immutable-releases": {"enabled": True},
+        "/repos/VanL/simplebroker/actions/permissions": {"sha_pinning_required": True},
+        "/repos/VanL/simplebroker/environments/pypi": {
+            "deployment_branch_policy": {
+                "protected_branches": False,
+                "custom_branch_policies": True,
+            }
+        },
+        "/repos/VanL/simplebroker/environments/pypi/deployment-branch-policies": {
+            "branch_policies": [
+                {"type": "tag", "name": "v*"},
+                {"type": "tag", "name": "simplebroker_pg/v*"},
+                {"type": "tag", "name": "simplebroker_redis/v*"},
+            ]
+        },
+        "/repos/VanL/simplebroker/rulesets": [
+            {
+                "id": 42,
+                "name": "Protect release tags",
+                "target": "tag",
+                "enforcement": "active",
+            }
+        ],
+        "/repos/VanL/simplebroker/rulesets/42": {
+            "id": 42,
+            "name": "Protect release tags",
+            "target": "tag",
+            "enforcement": "active",
+            "bypass_actors": [],
+            "conditions": {
+                "ref_name": {
+                    "include": [
+                        "refs/tags/v*",
+                        "refs/tags/simplebroker_pg/v*",
+                        "refs/tags/simplebroker_redis/v*",
+                    ],
+                    "exclude": [],
+                }
+            },
+            "rules": [{"type": "update"}, {"type": "deletion"}],
+        },
+    }
+
+
+def test_repository_settings_accept_only_the_hardened_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payloads = _repository_settings_payloads()
+    monkeypatch.setattr(
+        release,
+        "_github_api_json",
+        lambda path, token: payloads[path],
+    )
+
+    assert release.repository_settings_issues("VanL/simplebroker", "token") == ()
+
+
+@pytest.mark.parametrize(
+    ("key", "replacement", "message"),
+    (
+        (
+            "/repos/VanL/simplebroker/immutable-releases",
+            {"enabled": False},
+            "immutable releases",
+        ),
+        (
+            "/repos/VanL/simplebroker/actions/permissions",
+            {"sha_pinning_required": False},
+            "SHA pinning",
+        ),
+        (
+            "/repos/VanL/simplebroker/environments/pypi",
+            {"deployment_branch_policy": None},
+            "pypi environment",
+        ),
+        ("/repos/VanL/simplebroker/rulesets", [], "release-tag ruleset"),
+    ),
+)
+def test_repository_settings_report_each_missing_control(
+    monkeypatch: pytest.MonkeyPatch,
+    key: str,
+    replacement: object,
+    message: str,
+) -> None:
+    payloads = _repository_settings_payloads()
+    payloads[key] = replacement
+    monkeypatch.setattr(
+        release,
+        "_github_api_json",
+        lambda path, token: payloads[path],
+    )
+
+    issues = release.repository_settings_issues("VanL/simplebroker", "token")
+
+    assert any(message in issue for issue in issues)
+
+
+def test_release_helper_has_no_remote_tag_deletion_path() -> None:
+    source = (Path(__file__).resolve().parents[1] / "bin" / "release.py").read_text(
+        encoding="utf-8"
+    )
+
+    assert '"push", "--delete"' not in source
+    assert "replace_remote" not in source
+
+
+def test_local_only_wrong_tag_is_replaced_at_explicit_release_sha(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    commands: list[tuple[str, ...]] = []
+    sha = "a" * 40
+    monkeypatch.setattr(
+        release,
+        "run_command",
+        lambda command, **kwargs: commands.append(command),
+    )
+
+    release._prepare_tag_action(
+        _state(local="b" * 40),
+        tag_action="replace_local",
+        dry_run=False,
+        target_commit=sha,
+    )
+
+    assert commands == [
+        ("git", "tag", "-d", "v3.1.10"),
+        ("git", "tag", "v3.1.10", sha),
+    ]
+
+
+def test_real_release_branch_check_cannot_be_skipped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        release,
+        "require_backend_api_release_invariants",
+        lambda targets: None,
+    )
+    monkeypatch.setattr(release, "read_target_version", lambda target: "5.3.1")
+    monkeypatch.setattr(release, "is_dirty_worktree", lambda: False)
+    monkeypatch.setattr(
+        release,
+        "resolve_target_version",
+        lambda requested, current_version, target, dry_run=False: (
+            "5.3.2",
+            _state(),
+        ),
+    )
+    monkeypatch.setattr(release, "current_head_commit", lambda: "a" * 40)
+
+    def reject() -> None:
+        raise RuntimeError("must run from main")
+
+    monkeypatch.setattr(release, "require_main_branch", reject)
+
+    with pytest.raises(RuntimeError, match="must run from main"):
+        release.main(["core", "--version", "5.3.2", "--skip-checks"])
+
+
+def test_repository_settings_check_cannot_be_skipped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        release,
+        "require_backend_api_release_invariants",
+        lambda targets: None,
+    )
+    monkeypatch.setattr(release, "read_target_version", lambda target: "5.3.1")
+    monkeypatch.setattr(release, "is_dirty_worktree", lambda: False)
+    monkeypatch.setattr(
+        release,
+        "resolve_target_version",
+        lambda requested, current_version, target, dry_run=False: (
+            "5.3.2",
+            _state(),
+        ),
+    )
+    monkeypatch.setattr(release, "current_head_commit", lambda: "a" * 40)
+    monkeypatch.setattr(release, "require_main_branch", lambda: None)
+
+    def reject() -> None:
+        raise RuntimeError("repository settings blocked release")
+
+    monkeypatch.setattr(release, "require_repository_settings", reject)
+
+    with pytest.raises(RuntimeError, match="repository settings blocked release"):
+        release.main(["core", "--version", "5.3.2", "--skip-checks"])
+
+
+def test_interrupted_release_rerun_reuses_existing_release_commit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sha = "a" * 40
+    commands: list[tuple[str, ...]] = []
+    publications: list[tuple[tuple[release.ReleaseCandidate, ...], str]] = []
+    monkeypatch.setattr(
+        release,
+        "require_backend_api_release_invariants",
+        lambda targets: None,
+    )
+    monkeypatch.setattr(release, "read_target_version", lambda target: "5.3.2")
+    monkeypatch.setattr(release, "is_dirty_worktree", lambda: False)
+    monkeypatch.setattr(
+        release,
+        "resolve_target_version",
+        lambda requested, current_version, target, dry_run=False: (
+            "5.3.2",
+            _state(),
+        ),
+    )
+    monkeypatch.setattr(release, "current_head_commit", lambda: sha)
+    monkeypatch.setattr(release, "require_main_branch", lambda: None)
+    monkeypatch.setattr(release, "require_repository_settings", lambda: None)
+    monkeypatch.setattr(release, "_require_command", lambda name: None)
+    monkeypatch.setattr(release, "require_published_pg_baseline", lambda version: None)
+    monkeypatch.setattr(
+        release,
+        "require_published_redis_baseline",
+        lambda version: None,
+    )
+    monkeypatch.setattr(release, "read_pg_extension_version", lambda: "3.2.1")
+    monkeypatch.setattr(release, "read_redis_extension_version", lambda: "3.2.1")
+    monkeypatch.setattr(release, "sync_root_pg_extra_dependency", lambda: None)
+    monkeypatch.setattr(release, "sync_root_redis_extra_dependency", lambda: None)
+    monkeypatch.setattr(release, "build_postupdate_steps", lambda target: ())
+    monkeypatch.setattr(release, "release_files_changed", lambda target: False)
+    monkeypatch.setattr(
+        release,
+        "run_command",
+        lambda command, **kwargs: commands.append(command),
+    )
+    monkeypatch.setattr(
+        release,
+        "publish_release_tags_after_ci",
+        lambda candidates, release_sha: publications.append((candidates, release_sha)),
+    )
+
+    assert release.main(["core", "--skip-checks"]) == 0
+
+    assert not any(command[:2] == ("git", "commit") for command in commands)
+    assert len(publications) == 1
+    assert publications[0][1] == sha
+
+
+def test_remote_tag_is_read_again_after_ci_wait(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sha = "a" * 40
+    candidate = release.ReleaseCandidate(
+        target=release.ROOT_RELEASE_TARGET,
+        current_version="5.3.2",
+        release_version="5.3.2",
+        state=_state(),
+    )
+    monkeypatch.setattr(release, "run_command", lambda command, **kwargs: None)
+    monkeypatch.setattr(
+        release,
+        "wait_for_release_workflows",
+        lambda targets, release_sha, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        release,
+        "require_release_sha_on_origin_main",
+        lambda release_sha, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        release,
+        "inspect_release_state",
+        lambda version, target: _state(remote="b" * 40),
+    )
+
+    with pytest.raises(RuntimeError, match="Choose a new version"):
+        release.publish_release_tags_after_ci((candidate,), sha)

--- a/tests/test_release_script.py
+++ b/tests/test_release_script.py
@@ -1090,19 +1090,42 @@ def test_workflow_wait_passes_token_only_through_redacted_environment(
     assert "Test" in command
     assert "Test Postgres Extension" in command
     assert "top-secret-token" not in " ".join(command)
-    assert kwargs["env_overrides"] == {"GITHUB_TOKEN": "top-secret-token"}
-    assert kwargs["sensitive_env_keys"] == frozenset({"GITHUB_TOKEN"})
+    assert kwargs["private_env_overrides"] == {"GITHUB_TOKEN": "top-secret-token"}
+    assert "env_overrides" not in kwargs
 
 
 def test_sensitive_command_environment_is_redacted() -> None:
     rendered = release._format_command_prefix(
-        {"GITHUB_TOKEN": "top-secret-token", "SAFE": "visible"},
-        sensitive_env_keys=frozenset({"GITHUB_TOKEN"}),
+        {"SAFE": "visible"},
+        private_env_keys=frozenset({"GITHUB_TOKEN"}),
     )
 
-    assert "top-secret-token" not in rendered
     assert "GITHUB_TOKEN=<redacted>" in rendered
     assert "SAFE=visible" in rendered
+
+
+def test_private_command_environment_reaches_subprocess_but_not_log(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    observed_env: dict[str, str] = {}
+
+    def run(command: tuple[str, ...], **kwargs: object) -> None:
+        env = kwargs["env"]
+        assert isinstance(env, dict)
+        observed_env.update(env)
+
+    monkeypatch.setattr(release.subprocess, "run", run)
+
+    release.run_command(
+        ("example-command",),
+        private_env_overrides={"GITHUB_TOKEN": "top-secret-token"},
+    )
+
+    output = capsys.readouterr().out
+    assert observed_env["GITHUB_TOKEN"] == "top-secret-token"
+    assert "top-secret-token" not in output
+    assert "GITHUB_TOKEN=<redacted>" in output
 
 
 def test_release_sha_must_remain_reachable_from_fetched_main(

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -210,13 +210,117 @@ def test_release_gate_uploads_python_distributions_and_attestations() -> None:
         "release-gate-redis.yml",
     ):
         workflow_text = _workflow_text(workflow_path)
-        github_release_section = workflow_text.split("  github-release:", 1)[1]
+        github_release_section = workflow_text.split("  stage-github-release:", 1)[
+            1
+        ].split("  publish-to-pypi:", 1)[0]
 
         assert "dist/*.tar.gz" in github_release_section
         assert "dist/*.whl" in github_release_section
         assert "attestations/*.sigstore.json" in github_release_section
         assert "dist/*\n" not in github_release_section
         assert "id-token" not in github_release_section
+
+
+def test_release_gate_stages_draft_before_pypi_and_publishes_last() -> None:
+    for workflow_path in RELEASE_WORKFLOWS:
+        workflow_text = _workflow_text(workflow_path)
+
+        require_index = workflow_text.index("  require-tests:")
+        verify_index = workflow_text.index("  verify-tag-current:")
+        build_index = workflow_text.index("  build:")
+        stage_index = workflow_text.index("  stage-github-release:")
+        pypi_index = workflow_text.index("  publish-to-pypi:")
+        publish_index = workflow_text.index("  publish-github-release:")
+
+        assert require_index < verify_index < build_index < stage_index
+        assert stage_index < pypi_index < publish_index
+        stage_section = workflow_text[stage_index:pypi_index]
+        pypi_section = workflow_text[pypi_index:publish_index]
+        publish_section = workflow_text[publish_index:]
+        verify_section = workflow_text[verify_index:build_index]
+        build_section = workflow_text[build_index:stage_index]
+
+        assert "- require-tests" in verify_section
+        assert "- verify-tag-current" in build_section
+        assert "- build" in stage_section
+        assert "replace-draft" in stage_section
+        assert "draft: true" in stage_section
+        assert "uses: softprops/action-gh-release@" in stage_section
+        assert "publish-draft" in publish_section
+        assert "uses: softprops/action-gh-release@" not in publish_section
+        assert "files:" not in publish_section
+        assert "- stage-github-release" in pypi_section
+        assert "- publish-to-pypi" in publish_section
+
+
+def test_release_gate_uses_one_shared_publication_state_machine() -> None:
+    for workflow_path in RELEASE_WORKFLOWS:
+        workflow_text = _workflow_text(workflow_path)
+
+        assert workflow_text.count(".github/scripts/release_publication.py") == 2
+        assert "gh api" not in workflow_text
+        assert "gh release edit" not in workflow_text
+        assert "api.pypi.org" not in workflow_text
+        assert "pypi.org/pypi" not in workflow_text
+
+
+def test_release_gate_passes_github_context_to_shell_as_environment_data() -> None:
+    unsafe_shell_interpolations = (
+        '--repo "${{ github.repository }}"',
+        '--tag "${{ github.ref_name }}"',
+        '--expected-sha "${{ github.sha }}"',
+    )
+
+    for workflow_path in RELEASE_WORKFLOWS:
+        workflow_text = _workflow_text(workflow_path)
+
+        assert all(
+            interpolation not in workflow_text
+            for interpolation in unsafe_shell_interpolations
+        )
+        assert '--repo "${GITHUB_REPOSITORY}"' in workflow_text
+        assert '--tag "${GITHUB_REF_NAME}"' in workflow_text
+        assert '--expected-sha "${GITHUB_SHA}"' in workflow_text
+
+    for workflow_path in ("release-gate-pg.yml", "release-gate-redis.yml"):
+        workflow_text = _workflow_text(workflow_path)
+
+        assert 'run: echo "name=simplebroker-' not in workflow_text
+        assert "printf 'name=%s %s\\n'" in workflow_text
+
+
+def test_release_gate_attaches_all_assets_before_publishing() -> None:
+    for workflow_path in RELEASE_WORKFLOWS:
+        workflow_text = _workflow_text(workflow_path)
+        stage_section = workflow_text.split("  stage-github-release:", 1)[1].split(
+            "  publish-to-pypi:", 1
+        )[0]
+        publish_section = workflow_text.split("  publish-github-release:", 1)[1]
+
+        assert "dist/*.tar.gz" in stage_section
+        assert "dist/*.whl" in stage_section
+        assert "attestations/*.sigstore.json" in stage_section
+        assert "fail_on_unmatched_files: true" in stage_section
+        assert "--expected-asset" in publish_section
+        assert "find dist attestations" in publish_section
+        assert "dist/*.tar.gz" not in publish_section
+        assert "dist/*.whl" not in publish_section
+        assert "attestations/*.sigstore.json" not in publish_section
+
+
+def test_release_gate_pypi_job_keeps_tokenless_minimum_permissions() -> None:
+    forbidden_secrets = ("PYPI_TOKEN", "TWINE_PASSWORD", "password:", "api-token")
+
+    for workflow_path in RELEASE_WORKFLOWS:
+        workflow_text = _workflow_text(workflow_path)
+        pypi_section = workflow_text.split("  publish-to-pypi:", 1)[1].split(
+            "  publish-github-release:", 1
+        )[0]
+
+        assert "permissions:\n      id-token: write" in pypi_section
+        assert "contents: write" not in pypi_section
+        assert "actions: write" not in pypi_section
+        assert all(secret not in workflow_text for secret in forbidden_secrets)
 
 
 def test_release_gate_verifies_tag_matches_package_version() -> None:


### PR DESCRIPTION
## Summary
- move final release tag creation behind exact-SHA main CI and remove remote retagging
- add fail-closed repository settings verification and resumable pre-tag release flow
- stage complete draft releases before Trusted Publishing, then publish immutable releases through one shared state machine
- preserve local release pressure at logical CPU count plus one worker

## Local evidence
- focused release gate: 118 passed with 17 workers
- examples: 80 passed with 17 workers
- full core suite: green with 17 workers
- ruff, mypy, uv policy, YAML parsing, and dry-run order green

## Review fixes
- pass GitHub tag context into shell steps as environment data
- require exactly one wheel, one sdist, and one Sigstore bundle before publication

Plan: Task 3 / PR B only.